### PR TITLE
Remove setitem notation

### DIFF
--- a/grblas/__init__.py
+++ b/grblas/__init__.py
@@ -1,5 +1,5 @@
 import importlib
-from . import backends
+from . import backends  # noqa
 
 _init_params = None
 _SPECIAL_ATTRS = ["lib", "ffi", "Matrix", "Vector", "Scalar", "UnaryOp", "BinaryOp", "Monoid", "Semiring"]

--- a/grblas/__init__.py
+++ b/grblas/__init__.py
@@ -27,7 +27,7 @@ def init(backend="suitesparse", blocking=True):
 
 
 def _init(backend, blocking, automatic=False):
-    global lib, ffi, REPLACE, Matrix, Vector, Scalar, UnaryOp, BinaryOp, Monoid, Semiring, _init_params
+    global lib, ffi, Matrix, Vector, Scalar, UnaryOp, BinaryOp, Monoid, Semiring, _init_params
 
     passed_params = dict(backend=backend, blocking=blocking, automatic=automatic)
     if _init_params is None:
@@ -54,7 +54,6 @@ def _init(backend, blocking, automatic=False):
     else:
         ffi_backend.lib.GrB_init(ffi_backend.lib.GrB_NONBLOCKING)
 
-    from .base import REPLACE
     from .matrix import Matrix
     from .vector import Vector
     from .scalar import Scalar
@@ -72,4 +71,3 @@ def _init(backend, blocking, automatic=False):
     globals()["BinaryOp"] = BinaryOp
     globals()["Monoid"] = Monoid
     globals()["Semiring"] = Semiring
-    globals()["REPLACE"] = REPLACE

--- a/grblas/__init__.py
+++ b/grblas/__init__.py
@@ -1,27 +1,58 @@
 import importlib
 from . import backends
 
-lib = None
-ffi = None
-REPLACE = None
-Matrix = None
-Vector = None
-Scalar = None
-UnaryOp, BinaryOp, Monoid, Semiring = None, None, None, None
+_init_params = None
+_SPECIAL_ATTRS = ["lib", "ffi", "Matrix", "Vector", "Scalar", "UnaryOp", "BinaryOp", "Monoid", "Semiring"]
 
-def init(backend='suitesparse', blocking=True):
-    global lib, ffi, REPLACE, Matrix, Vector, Scalar, UnaryOp, BinaryOp, Monoid, Semiring
+
+def __getattr__(name):
+    """Auto-initialize if special attrs used without explicit init call by user"""
+    if name in _SPECIAL_ATTRS:
+        _init("suitesparse", True, automatic=True)
+
+        return globals()[name]
+    else:
+        raise AttributeError(f"module {__name__!r} has not attribute {name!r}")
+
+
+def __dir__():
+    attrs = list(globals())
+    if "lib" not in attrs:
+        attrs += _SPECIAL_ATTRS
+    return attrs
+
+
+def init(backend="suitesparse", blocking=True):
+    _init(backend, blocking)
+
+
+def _init(backend, blocking, automatic=False):
+    global lib, ffi, REPLACE, Matrix, Vector, Scalar, UnaryOp, BinaryOp, Monoid, Semiring, _init_params
+
+    passed_params = dict(backend=backend, blocking=blocking, automatic=automatic)
+    if _init_params is None:
+        _init_params = passed_params
+    else:
+        if _init_params != passed_params:
+            from .exceptions import GrblasException
+            if _init_params.get("automatic"):
+                raise GrblasException("grblas objects accessed prior to manual initialization")
+            else:
+                raise GrblasException("grblas initialized multiple times with different init parameters")
+
+        # Already initialized with these parameters; nothing more to do
+        return
 
     ffi_backend = importlib.import_module(f'.backends.{backend}', __name__)
 
-    lib = ffi_backend.lib
-    ffi = ffi_backend.ffi
+    globals()["lib"] = ffi_backend.lib
+    globals()["ffi"] = ffi_backend.ffi
 
     # This must be called before anything else happens
     if blocking:
-        lib.GrB_init(lib.GrB_BLOCKING)
+        ffi_backend.lib.GrB_init(ffi_backend.lib.GrB_BLOCKING)
     else:
-        lib.GrB_init(lib.GrB_NONBLOCKING)
+        ffi_backend.lib.GrB_init(ffi_backend.lib.GrB_NONBLOCKING)
 
     from .base import REPLACE
     from .matrix import Matrix
@@ -33,3 +64,12 @@ def init(backend='suitesparse', blocking=True):
     BinaryOp._initialize()
     Monoid._initialize()
     Semiring._initialize()
+
+    globals()["Matrix"] = Matrix
+    globals()["Vector"] = Vector
+    globals()["Scalar"] = Scalar
+    globals()["UnaryOp"] = UnaryOp
+    globals()["BinaryOp"] = BinaryOp
+    globals()["Monoid"] = Monoid
+    globals()["Semiring"] = Semiring
+    globals()["REPLACE"] = REPLACE

--- a/grblas/__init__.py
+++ b/grblas/__init__.py
@@ -45,8 +45,8 @@ def _init(backend, blocking, automatic=False):
 
     ffi_backend = importlib.import_module(f'.backends.{backend}', __name__)
 
-    globals()["lib"] = ffi_backend.lib
-    globals()["ffi"] = ffi_backend.ffi
+    lib = ffi_backend.lib
+    ffi = ffi_backend.ffi
 
     # This must be called before anything else happens
     if blocking:
@@ -63,11 +63,3 @@ def _init(backend, blocking, automatic=False):
     BinaryOp._initialize()
     Monoid._initialize()
     Semiring._initialize()
-
-    globals()["Matrix"] = Matrix
-    globals()["Vector"] = Vector
-    globals()["Scalar"] = Scalar
-    globals()["UnaryOp"] = UnaryOp
-    globals()["BinaryOp"] = BinaryOp
-    globals()["Monoid"] = Monoid
-    globals()["Semiring"] = Semiring

--- a/grblas/__init__.py
+++ b/grblas/__init__.py
@@ -2,7 +2,8 @@ import importlib
 from . import backends  # noqa
 
 _init_params = None
-_SPECIAL_ATTRS = ["lib", "ffi", "Matrix", "Vector", "Scalar", "UnaryOp", "BinaryOp", "Monoid", "Semiring"]
+_SPECIAL_ATTRS = ["lib", "ffi", "Matrix", "Vector", "Scalar", "UnaryOp", "BinaryOp", "Monoid", "Semiring",
+                  "base", "exceptions", "matrix", "ops", "scalar", "vector"]
 
 
 def __getattr__(name):
@@ -28,6 +29,7 @@ def init(backend="suitesparse", blocking=True):
 
 def _init(backend, blocking, automatic=False):
     global lib, ffi, Matrix, Vector, Scalar, UnaryOp, BinaryOp, Monoid, Semiring, _init_params
+    global base, exceptions, matrix, ops, scalar, vector
 
     passed_params = dict(backend=backend, blocking=blocking, automatic=automatic)
     if _init_params is None:
@@ -54,6 +56,12 @@ def _init(backend, blocking, automatic=False):
     else:
         ffi_backend.lib.GrB_init(ffi_backend.lib.GrB_NONBLOCKING)
 
+    ops = importlib.import_module(f".ops", __name__)
+    exceptions = importlib.import_module(f".exceptions", __name__)
+    base = importlib.import_module(f".base", __name__)
+    matrix = importlib.import_module(f".matrix", __name__)
+    vector = importlib.import_module(f".vector", __name__)
+    scalar = importlib.import_module(f".scalar", __name__)
     from .matrix import Matrix
     from .vector import Vector
     from .scalar import Scalar

--- a/grblas/backends/python/Scratch pad for python backend.ipynb
+++ b/grblas/backends/python/Scratch pad for python backend.ipynb
@@ -1,0 +1,1845 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numba\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import networkx as nx\n",
+    "import scipy\n",
+    "from scipy.sparse import csr_matrix, coo_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def vrepr(v):\n",
+    "    nrows, ncols = v.shape\n",
+    "    assert nrows == 1\n",
+    "    df = pd.DataFrame(index=range(ncols), columns=[''])\n",
+    "    coo = v.tocoo()\n",
+    "    for i, val in zip(coo.col, coo.data):\n",
+    "        df.iloc[i] = val\n",
+    "    return df.where(pd.notnull(df), '')\n",
+    "\n",
+    "def hrepr(v):\n",
+    "    return vrepr(v).T\n",
+    "\n",
+    "def mrepr(m):\n",
+    "    nrows, ncols = m.shape\n",
+    "    df = pd.DataFrame(columns=range(ncols), index=range(nrows))\n",
+    "    coo = m.tocoo()\n",
+    "    for i, j, val in zip(coo.row, coo.col, coo.data):\n",
+    "        df.iloc[i, j] = val\n",
+    "    return df.where(pd.notnull(df), '')\n",
+    "\n",
+    "def draw(m):\n",
+    "    g = nx.DiGraph()\n",
+    "    coo = m.tocoo()\n",
+    "    for row, col, val in zip(coo.row, coo.col, coo.data):\n",
+    "        g.add_edge(row, col, weight=val)\n",
+    "    pos = nx.spring_layout(g)\n",
+    "    edge_labels = {(i, j): d['weight'] for i, j, d in g.edges(data=True)}\n",
+    "    nx.draw_networkx(g, pos, node_color='red', node_size=500)\n",
+    "    nx.draw_networkx_edge_labels(g, pos, edge_labels=edge_labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = [\n",
+    "    [3,0,3,5,6,0,6,1,6,2,4,1],\n",
+    "    [0,1,2,2,2,3,3,4,4,5,5,6],\n",
+    "    [3,2,3,1,5,3,7,8,3,1,7,4]\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows, cols, weights = data\n",
+    "m = coo_matrix((weights, (rows, cols)), shape=(7, 7))\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = m.tocsr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.nnz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.toarray()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mrepr(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "draw(m)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How to update values without changing nnz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = m.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2.data = np.array([1]*len(m2.data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2.toarray()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(m * m2).toarray()  # Appears to do matrix multiplication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.multiply(m2).toarray()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.toarray()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.tocoo().col"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sparse vector?\n",
+    "\n",
+    "Simulate by using a (1 x n) sparse matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v = coo_matrix(([1], ([0], [1])), shape=(1, 7))\n",
+    "v = v.tocsr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v.toarray()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hrepr(v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Attributes of csr_matrix object\n",
+    "\n",
+    "Because scipy.sparse has no concept of semirings, we will need to implement lots of things in numba.\n",
+    "\n",
+    "To work efficiently, we need access to the underlying array objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.dtype"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.indices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.indptr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mrepr(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.nnz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.nonzero()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(m.indptr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Can we update sparse matrices without changing the shape?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.data = np.array([2,3,8,4,1,3,3,7,1,5,7,3,2], dtype=np.int64)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.indices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.indices = np.array([1,3,4,6,5,0,2,5,2,2,3,4,5], dtype=np.int32)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.indices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.indptr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.indptr = np.array([0,2,4,5,7,8,9,13], dtype=np.int32)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.indptr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.toarray()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mrepr(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.nnz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Use Numba to perform matrix multiplication with a semiring"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@numba.njit\n",
+    "def numba_plus(x, y):\n",
+    "    return x + y\n",
+    "\n",
+    "@numba.njit\n",
+    "def numba_times(x, y):\n",
+    "    return x * y\n",
+    "\n",
+    "@numba.njit\n",
+    "def numba_min(x, y):\n",
+    "    return min(x, y)\n",
+    "\n",
+    "@numba.njit\n",
+    "def numba_max(x, y):\n",
+    "    return max(x, y)\n",
+    "\n",
+    "@numba.njit\n",
+    "def numba_bnot(x):\n",
+    "    return ~x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@numba.njit\n",
+    "def mxm(C, A, B, semiring):\n",
+    "    cr, cc = C.shape\n",
+    "    ar, ac = A.shape\n",
+    "    br, bc = B.shape\n",
+    "    if cr != ar:\n",
+    "        return -1\n",
+    "    if cc != bc:\n",
+    "        return -1\n",
+    "    if ac != br:\n",
+    "        return -1\n",
+    "    plus, times, identity = semiring\n",
+    "    for i in range(cr):\n",
+    "        for j in range(cc):\n",
+    "            val = identity\n",
+    "            for k in range(ac):\n",
+    "                val = plus(val, times(A[i, k], B[k, j]))\n",
+    "            C[i, j] = val\n",
+    "    return 0\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = np.array([[1, 2, 3], [4, 5, 6]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "B = np.array([[1], [5], [9]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "B"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A.dot(B)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "C = np.array([[1], [1]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mxm(C, A, B, (numba_plus, numba_times, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "C"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mxm(C, A, B, (numba_max, numba_plus, 0))\n",
+    "C"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mxm(C, A, B, (numba_min, numba_plus, np.iinfo(A.dtype).max))\n",
+    "C"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Can we use sparse matrices?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v = coo_matrix(([0], ([0], [1])), shape=(1, 7)).tocsr()\n",
+    "hrepr(v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows, cols, weights = data\n",
+    "m = coo_matrix((weights, (rows, cols)), shape=(7, 7)).tocsr()\n",
+    "mrepr(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "C = coo_matrix(([], ([], [])), shape=(1, 7), dtype=np.int64).tocsr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hrepr(C)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "semiring = (numba_min, numba_plus, np.iinfo(A.dtype).max)\n",
+    "mxm(C, v, m, semiring)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mxm(C, A, B, semiring):\n",
+    "    cr, cc = C.shape\n",
+    "    ar, ac = A.shape\n",
+    "    br, bc = B.shape\n",
+    "    if cr != ar:\n",
+    "        return -1\n",
+    "    if cc != bc:\n",
+    "        return -1\n",
+    "    if ac != br:\n",
+    "        return -1\n",
+    "    plus, times, identity = semiring\n",
+    "    b = B.tocsc()\n",
+    "    d, i, ip = _mxm(A.data, A.indices, A.indptr, b.data, b.indices, b.indptr, plus, times, identity, C.dtype)\n",
+    "    C.data = d\n",
+    "    C.indices = i\n",
+    "    C.indptr = ip\n",
+    "    return 0\n",
+    "\n",
+    "@numba.njit\n",
+    "def _mxm(a_data, a_indices, a_indptr, b_data, b_indices, b_indptr, plus, times, identity, dtype):\n",
+    "    # Final array size is unknown, so we give ourselves room and then adjust on the fly\n",
+    "    tmp_output_size = a_data.size * 2\n",
+    "    data = np.empty((tmp_output_size,), dtype=dtype)\n",
+    "    indices = np.empty((tmp_output_size,), dtype=a_indices.dtype)\n",
+    "    indptr = np.empty((a_indptr.size,), dtype=a_indptr.dtype)\n",
+    "    output_counter = 0\n",
+    "    for iptr in range(a_indptr.size - 1):\n",
+    "        indptr[iptr] = output_counter\n",
+    "        for jptr in range(b_indptr.size - 1):\n",
+    "            a_counter = a_indptr[iptr]\n",
+    "            a_stop = a_indptr[iptr+1]\n",
+    "            b_counter = b_indptr[jptr]\n",
+    "            b_stop = b_indptr[jptr+1]\n",
+    "            val = identity\n",
+    "            nonempty = False\n",
+    "            while a_counter < a_stop and b_counter < b_stop:\n",
+    "                a_k = a_indices[a_counter]\n",
+    "                b_k = b_indices[b_counter]\n",
+    "                if a_k == b_k:\n",
+    "                    val = plus(val, times(a_data[a_counter], b_data[b_counter]))\n",
+    "                    nonempty = True\n",
+    "                    a_counter += 1\n",
+    "                    b_counter += 1\n",
+    "                elif a_k < b_k:\n",
+    "                    a_counter += 1\n",
+    "                else:\n",
+    "                    b_counter += 1\n",
+    "            if nonempty:\n",
+    "                if output_counter >= tmp_output_size:\n",
+    "                    # We filled up the allocated space; copy existing data to a larger array\n",
+    "                    tmp_output_size *= 2\n",
+    "                    new_data = np.empty((tmp_output_size,), dtype=data.dtype)\n",
+    "                    new_indices = np.empty((tmp_output_size,), dtype=indices.dtype)\n",
+    "                    new_data[:output_counter] = data[:output_counter]\n",
+    "                    new_indices[:output_counter] = indices[:output_counter]\n",
+    "                    data = new_data\n",
+    "                    indices = new_indices\n",
+    "                data[output_counter] = val\n",
+    "                indices[output_counter] = jptr\n",
+    "                output_counter += 1\n",
+    "    # Add final entry to indptr (should indicate nnz in the output)\n",
+    "    nnz = output_counter\n",
+    "    indptr[iptr + 1] = nnz\n",
+    "    # Trim output arrays\n",
+    "    data = data[:nnz]\n",
+    "    indices = indices[:nnz]\n",
+    "    \n",
+    "    return (data, indices, indptr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.indices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.indptr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mrepr(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hmm, this is problematic. Apparently scipy.sparse considers empty to be zero when doing dot product.\n",
+    "# It should have two non-empty elements, both of which have a value of 0.\n",
+    "v.dot(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td></td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td></td>\n",
+       "      <td>5</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   0  1  2\n",
+       "0  1     3\n",
+       "1     5  6"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "A = coo_matrix(([1,3,5,6], ([0,0,1,1], [0,2,1,2])), shape=(2, 3)).tocsr()\n",
+    "mrepr(A)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>5</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td></td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   0  1\n",
+       "0  1   \n",
+       "1  5   \n",
+       "2     7"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "B = coo_matrix(([1,5,7], ([0,1,2], [0,0,1])), shape=(3, 2)).tocsr()\n",
+    "b = B.tocsc()\n",
+    "mrepr(B)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  0 1\n",
+       "0    \n",
+       "1    "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "C = coo_matrix(([], ([], [])), shape=(2, 2), dtype=np.int64).tocsr()\n",
+    "mrepr(C)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mxm(C, A, B, (plus, times, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1, 3, 5, 6], dtype=int64)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "A.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 2, 1, 2], dtype=int32)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "A.indices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 2, 4], dtype=int32)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "A.indptr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1, 5, 7], dtype=int64)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 1, 2], dtype=int32)"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b.indices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 2, 3], dtype=int32)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b.indptr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 1, 21, 25, 42])"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "C.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 1, 0, 1], dtype=int32)"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "C.indices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 2, 4], dtype=int32)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "C.indptr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mrepr(C)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.empty((1,), np.uint)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_318[0] = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_318[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(np.uint) is type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(float) is type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Matrix:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(Matrix) is type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.dtype(Matrix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_333 == object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.dtype(np.bool)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_340 == object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = scipy.sparse.csr_matrix((4, 3), dtype=np.int32)\n",
+    "y = csr_matrix(([7], ([0], [0])), shape=(4, 3), dtype=np.int32)\n",
+    "z = csr_matrix(y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z is y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z.data is y.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z[0, 1] = 12"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z.toarray()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y.toarray()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z.resize((12, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z.toarray()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "not True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "not (True ^ True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "~(5 ^ 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "5 // 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numba import types as nt\n",
+    "from numba import njit\n",
+    "\n",
+    "# Most operations with semirings will require numba\n",
+    "# Even if an equivalent function exists in numpy or scipy, numba\n",
+    "# doesn't seem to like it as much as a jit'd function doing the same thing\n",
+    "\n",
+    "_unary_bool = [nt.boolean(nt.boolean)]\n",
+    "_unary_int = [nt.uint8(nt.uint8),\n",
+    "              nt.int8(nt.int8),\n",
+    "              nt.uint16(nt.uint16),\n",
+    "              nt.int16(nt.int16),\n",
+    "              nt.uint32(nt.uint32),\n",
+    "              nt.int32(nt.int32),\n",
+    "              nt.uint64(nt.uint64),\n",
+    "              nt.int64(nt.int64)]\n",
+    "_unary_float = [nt.float32(nt.float32),\n",
+    "                nt.float64(nt.float64)]\n",
+    "_unary_all = _unary_bool + _unary_int + _unary_float\n",
+    "\n",
+    "_binary_bool = [nt.boolean(nt.boolean, nt.boolean)]\n",
+    "_binary_int = [nt.uint8(nt.uint8, nt.uint8),\n",
+    "               nt.int8(nt.int8, nt.int8),\n",
+    "               nt.uint16(nt.uint16, nt.uint16),\n",
+    "               nt.int16(nt.int16, nt.int16),\n",
+    "               nt.uint32(nt.uint32, nt.uint32),\n",
+    "               nt.int32(nt.int32, nt.int32),\n",
+    "               nt.uint64(nt.uint64, nt.uint64),\n",
+    "               nt.int64(nt.int64, nt.int64)]\n",
+    "_binary_float = [nt.float32(nt.float32, nt.float32),\n",
+    "                 nt.float64(nt.float64, nt.float64)]\n",
+    "_binary_all = _binary_bool + _binary_int + _binary_float\n",
+    "\n",
+    "_binary_int_to_bool = [nt.boolean(nt.uint8, nt.uint8),\n",
+    "                       nt.boolean(nt.int8, nt.int8),\n",
+    "                       nt.boolean(nt.uint16, nt.uint16),\n",
+    "                       nt.boolean(nt.int16, nt.int16),\n",
+    "                       nt.boolean(nt.uint32, nt.uint32),\n",
+    "                       nt.boolean(nt.int32, nt.int32),\n",
+    "                       nt.boolean(nt.uint64, nt.uint64),\n",
+    "                       nt.boolean(nt.int64, nt.int64)]\n",
+    "_binary_float_to_bool = [nt.boolean(nt.float32, nt.float32),\n",
+    "                         nt.boolean(nt.float64, nt.float64)]\n",
+    "_binary_all_to_bool = _binary_bool + _binary_int_to_bool + _binary_float_to_bool\n",
+    "\n",
+    "\n",
+    "#################\n",
+    "# Unary Operators\n",
+    "#################\n",
+    "\n",
+    "@njit(_unary_all)\n",
+    "def identity(x):\n",
+    "    \"\"\"Identity\"\"\"\n",
+    "    return x\n",
+    "\n",
+    "@njit(_unary_all)\n",
+    "def abs(x):\n",
+    "    \"\"\"Absolute value\"\"\"\n",
+    "    return abs(x)\n",
+    "\n",
+    "@njit(_unary_int + _unary_float)\n",
+    "def ainv(x):\n",
+    "    \"\"\"Additive inverse\"\"\"\n",
+    "    return -x\n",
+    "\n",
+    "@njit(_unary_float)\n",
+    "def minv(x):\n",
+    "    \"\"\"Multiplicative inverse\"\"\"\n",
+    "    return 1/x\n",
+    "\n",
+    "@njit(_unary_bool)\n",
+    "def lnot(x):\n",
+    "    \"\"\"Logical inverse\"\"\"\n",
+    "    return not x\n",
+    "\n",
+    "@njit(_unary_int)\n",
+    "def bnot(x):\n",
+    "    \"\"\"Bitwise complement\"\"\"\n",
+    "    return ~x\n",
+    "\n",
+    "\n",
+    "##################\n",
+    "# Binary Operators\n",
+    "##################\n",
+    "\n",
+    "@njit(_binary_bool)\n",
+    "def lor(x, y):\n",
+    "    \"\"\"Logical OR\"\"\"\n",
+    "    return x | y\n",
+    "\n",
+    "@njit(_binary_bool)\n",
+    "def land(x, y):\n",
+    "    \"\"\"Logical AND\"\"\"\n",
+    "    return x & y\n",
+    "\n",
+    "@njit(_binary_bool)\n",
+    "def lxor(x, y):\n",
+    "    \"\"\"Logical XOR\"\"\"\n",
+    "    return x ^ y\n",
+    "\n",
+    "@njit(_binary_bool)\n",
+    "def lxnor(x, y):\n",
+    "    \"\"\"Logical XNOR\"\"\"\n",
+    "    return not (x ^ y)\n",
+    "\n",
+    "@njit(_binary_int)\n",
+    "def bor(x, y):\n",
+    "    \"\"\"Bitwise OR\"\"\"\n",
+    "    return x | y\n",
+    "\n",
+    "@njit(_binary_int)\n",
+    "def band(x, y):\n",
+    "    \"\"\"Bitwise AND\"\"\"\n",
+    "    return x & y\n",
+    "\n",
+    "@njit(_binary_int)\n",
+    "def bxor(x, y):\n",
+    "    \"\"\"Bitwise XOR\"\"\"\n",
+    "    return x ^ y\n",
+    "\n",
+    "@njit(_binary_int)\n",
+    "def bxnor(x, y):\n",
+    "    \"\"\"Bitwise XNOR\"\"\"\n",
+    "    return ~(x ^ y)\n",
+    "\n",
+    "@njit(_binary_all_to_bool)\n",
+    "def eq(x, y):\n",
+    "    \"\"\"Equal\"\"\"\n",
+    "    return x == y\n",
+    "\n",
+    "@njit(_binary_all_to_bool)\n",
+    "def ne(x, y):\n",
+    "    \"\"\"Not equal\"\"\"\n",
+    "    return x != y\n",
+    "\n",
+    "@njit(_binary_all_to_bool)\n",
+    "def gt(x, y):\n",
+    "    \"\"\"Greater than\"\"\"\n",
+    "    return x > y\n",
+    "\n",
+    "@njit(_binary_all_to_bool)\n",
+    "def lt(x, y):\n",
+    "    \"\"\"Less than\"\"\"\n",
+    "    return x < y\n",
+    "\n",
+    "@njit(_binary_all_to_bool)\n",
+    "def ge(x, y):\n",
+    "    \"\"\"Greater than or equal\"\"\"\n",
+    "    return x >= y\n",
+    "\n",
+    "@njit(_binary_all_to_bool)\n",
+    "def le(x, y):\n",
+    "    \"\"\"Less than or equal\"\"\"\n",
+    "    return x <= y\n",
+    "\n",
+    "@njit(_binary_all)\n",
+    "def first(x, y):\n",
+    "    \"\"\"First argument\"\"\"\n",
+    "    return x\n",
+    "\n",
+    "@njit(_binary_all)\n",
+    "def second(x, y):\n",
+    "    \"\"\"Second argument\"\"\"\n",
+    "    return y\n",
+    "\n",
+    "@njit(_binary_int + _binary_float)\n",
+    "def min(x, y):\n",
+    "    \"\"\"Minimum\"\"\"\n",
+    "    return min(x, y)\n",
+    "\n",
+    "@njit(_binary_int + _binary_float)\n",
+    "def max(x, y):\n",
+    "    \"\"\"Maximum\"\"\"\n",
+    "    return max(x, y)\n",
+    "\n",
+    "@njit(_binary_int + _binary_float)\n",
+    "def plus(x, y):\n",
+    "    \"\"\"Addition\"\"\"\n",
+    "    return x + y\n",
+    "\n",
+    "@njit(_binary_int + _binary_float)\n",
+    "def minus(x, y):\n",
+    "    \"\"\"Subtraction\"\"\"\n",
+    "    return x - y\n",
+    "\n",
+    "@njit(_binary_int + _binary_float)\n",
+    "def times(x, y):\n",
+    "    \"\"\"Multiplication\"\"\"\n",
+    "    return x * y\n",
+    "\n",
+    "@njit(_binary_int)\n",
+    "def floordiv(x, y):\n",
+    "    \"\"\"Integer division (ex. 5/4=1)\"\"\"\n",
+    "    return x // y\n",
+    "\n",
+    "@njit(_binary_float)\n",
+    "def truediv(x, y):\n",
+    "    \"\"\"Float division (ex. 5/4=1.25)\"\"\"\n",
+    "    return x / y\n",
+    "\n",
+    "@njit(_binary_int + _binary_float)\n",
+    "def div(x, y):\n",
+    "    return x / y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/jkitchen/Projects/HIVE/grblas/grblas/backends\n"
+     ]
+    }
+   ],
+   "source": [
+    "cd .."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import python as py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "py.GrB_BinaryOp.GrB_LXOR(False, False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/grblas/backends/python/__init__.py
+++ b/grblas/backends/python/__init__.py
@@ -1,4 +1,4 @@
-from .constants import *
+from .constants import *  # noqa
 
 # NOTE: This backend is meant to be used for prototyping, not for production use
 #       It is still in early-alpha stage with most methods not yet implemented.

--- a/grblas/backends/python/descriptors.py
+++ b/grblas/backends/python/descriptors.py
@@ -2,6 +2,7 @@ from .exceptions import GrB_Info, return_error
 from .context import handle_panic
 from .base import BasePointer
 
+
 class GrB_Desc_Field:
     GrB_OUTP = object()
     GrB_INP0 = object()

--- a/grblas/backends/python/exceptions.py
+++ b/grblas/backends/python/exceptions.py
@@ -20,6 +20,7 @@ class GrB_Info:
 class GraphBlasException(Exception):
     pass
 
+
 last_error_message = None
 
 

--- a/grblas/backends/python/operators.py
+++ b/grblas/backends/python/operators.py
@@ -73,30 +73,36 @@ _binary_all_to_bool = _binary_bool + _binary_int_to_bool + _binary_float_to_bool
 # Unary Operators
 #################
 
+
 @GrB_UnaryOp._compile(_unary_all)
 def identity(x):
     """Identity"""
     return x
+
 
 @GrB_UnaryOp._compile(_unary_int + _unary_float)
 def abs(x):
     """Absolute value"""
     return abs(x)
 
+
 @GrB_UnaryOp._compile(_unary_int + _unary_float)
 def ainv(x):
     """Additive inverse"""
     return -x
+
 
 @GrB_UnaryOp._compile(_unary_float)
 def minv(x):
     """Multiplicative inverse"""
     return 1/x
 
+
 @GrB_UnaryOp._compile(_unary_bool, nosuffix=True)
 def lnot(x):
     """Logical inverse"""
     return not x
+
 
 @GrB_UnaryOp._compile(_unary_int)
 def bnot(x):
@@ -113,105 +119,126 @@ def lor(x, y):
     """Logical OR"""
     return x | y
 
+
 @GrB_BinaryOp._compile(_binary_bool, nosuffix=True)
 def land(x, y):
     """Logical AND"""
     return x & y
+
 
 @GrB_BinaryOp._compile(_binary_bool, nosuffix=True)
 def lxor(x, y):
     """Logical XOR"""
     return x ^ y
 
+
 @GrB_BinaryOp._compile(_binary_bool, nosuffix=True)
 def lxnor(x, y):
     """Logical XNOR"""
     return not (x ^ y)
+
 
 @GrB_BinaryOp._compile(_binary_int)
 def bor(x, y):
     """Bitwise OR"""
     return x | y
 
+
 @GrB_BinaryOp._compile(_binary_int)
 def band(x, y):
     """Bitwise AND"""
     return x & y
+
 
 @GrB_BinaryOp._compile(_binary_int)
 def bxor(x, y):
     """Bitwise XOR"""
     return x ^ y
 
+
 @GrB_BinaryOp._compile(_binary_int)
 def bxnor(x, y):
     """Bitwise XNOR"""
     return ~(x ^ y)
+
 
 @GrB_BinaryOp._compile(_binary_all_to_bool)
 def eq(x, y):
     """Equal"""
     return x == y
 
+
 @GrB_BinaryOp._compile(_binary_all_to_bool)
 def ne(x, y):
     """Not equal"""
     return x != y
+
 
 @GrB_BinaryOp._compile(_binary_all_to_bool)
 def gt(x, y):
     """Greater than"""
     return x > y
 
+
 @GrB_BinaryOp._compile(_binary_all_to_bool)
 def lt(x, y):
     """Less than"""
     return x < y
+
 
 @GrB_BinaryOp._compile(_binary_all_to_bool)
 def ge(x, y):
     """Greater than or equal"""
     return x >= y
 
+
 @GrB_BinaryOp._compile(_binary_all_to_bool)
 def le(x, y):
     """Less than or equal"""
     return x <= y
+
 
 @GrB_BinaryOp._compile(_binary_all)
 def first(x, y):
     """First argument"""
     return x
 
+
 @GrB_BinaryOp._compile(_binary_all)
 def second(x, y):
     """Second argument"""
     return y
+
 
 @GrB_BinaryOp._compile(_binary_int + _binary_float)
 def min(x, y):
     """Minimum"""
     return min(x, y)
 
+
 @GrB_BinaryOp._compile(_binary_int + _binary_float)
 def max(x, y):
     """Maximum"""
     return max(x, y)
+
 
 @GrB_BinaryOp._compile(_binary_int + _binary_float)
 def plus(x, y):
     """Addition"""
     return x + y
 
+
 @GrB_BinaryOp._compile(_binary_int + _binary_float)
 def minus(x, y):
     """Subtraction"""
     return x - y
 
+
 @GrB_BinaryOp._compile(_binary_int + _binary_float)
 def times(x, y):
     """Multiplication"""
     return x * y
+
 
 @GrB_BinaryOp._compile(_binary_int + _binary_float)
 def div(x, y):

--- a/grblas/backends/suitesparse/__init__.py
+++ b/grblas/backends/suitesparse/__init__.py
@@ -1,1 +1,1 @@
-from ._suitesparse_grblas import ffi, lib
+from ._suitesparse_grblas import ffi, lib  # noqa

--- a/grblas/backends/suitesparse/build.py
+++ b/grblas/backends/suitesparse/build.py
@@ -15,4 +15,3 @@ ffibuilder.cdef(gb_cdef.read())
 
 if __name__ == '__main__':
     ffibuilder.compile(verbose=True)
-

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -15,7 +15,7 @@ class Updater:
         # Occurs when user calls C(params)[index]; need something prepared to receive `<<` or `.update()`
         if self.parent.is_scalar:
             raise TypeError('Indexing not supported for Scalars')
-        if type(keys) == IndexerResolver:
+        if type(keys) is IndexerResolver:
             resolved_indexes = keys
         else:
             resolved_indexes = IndexerResolver(self.parent, keys)
@@ -25,7 +25,7 @@ class Updater:
         # Occurs when user calls C(params)[index] = delayed
         if self.parent.is_scalar:
             raise TypeError('Indexing not supported for Scalars')
-        if type(keys) == IndexerResolver:
+        if type(keys) is IndexerResolver:
             resolved_indexes = keys
         else:
             resolved_indexes = IndexerResolver(self.parent, keys)
@@ -82,11 +82,11 @@ class GbContainer:
         for key in optional_mask_and_accum:
             if isinstance(key, GbContainer):
                 mask_arg = key
-            elif type(key) == ComplementedMask:
+            elif type(key) is ComplementedMask:
                 mask_arg = key
             elif isinstance(key, ops.BinaryOp):
                 accum_arg = key
-            elif type(key) == ffi.CData and ops.find_opclass(key) != ops.UNKNOWN_OPCLASS:
+            elif type(key) is ffi.CData and ops.find_opclass(key) != ops.UNKNOWN_OPCLASS:
                 accum_arg = key
             else:
                 raise TypeError(f'Invalid item found in output params: {type(key)}')
@@ -119,13 +119,13 @@ class GbContainer:
         if not isinstance(delayed, GbDelayed):
             from .ops import UnaryOp
             from .matrix import Matrix, TransposedMatrix
-            if type(delayed) == AmbiguousAssignOrExtract:
+            if type(delayed) is AmbiguousAssignOrExtract:
                 # Extract (C << A[rows, cols])
                 delayed = delayed._extract_delayed()
-            elif type(delayed) == self.__class__:
+            elif type(delayed) is self.__class__:
                 # Simple assignment (w << v)
                 delayed = delayed.apply(UnaryOp.IDENTITY)
-            elif type(delayed) == TransposedMatrix and type(self) == Matrix:
+            elif type(delayed) is TransposedMatrix and type(self) is Matrix:
                 # Transpose (C << A.T)
                 delayed = GbDelayed(lib.GrB_transpose, [delayed.gb_obj[0]])
             else:
@@ -137,7 +137,7 @@ class GbContainer:
             pass
         elif isinstance(mask, GbContainer):
             mask = mask.gb_obj[0]
-        elif type(mask) == ComplementedMask:
+        elif type(mask) is ComplementedMask:
             mask = mask.mask.gb_obj[0]
             complement = True
         else:
@@ -148,7 +148,7 @@ class GbContainer:
             pass
         elif isinstance(accum, ops.BinaryOp):
             accum = accum[self.dtype]
-        elif type(accum) == ffi.CData and ops.find_opclass(accum) != ops.UNKNOWN_OPCLASS:
+        elif type(accum) is ffi.CData and ops.find_opclass(accum) != ops.UNKNOWN_OPCLASS:
             pass
         else:
             raise TypeError(f"Invalid accum: {type(accum)}")
@@ -338,16 +338,16 @@ class IndexerResolver:
         return out
 
     def parse_index(self, index, typ, size):
-        if typ == int:
+        if typ is int:
             if index >= size:
                 raise IndexError(f'index={index}, size={size}')
             return index, None
-        if typ == slice:
+        if typ is slice:
             if index == slice(None):
                 # [:] means all indices; use special GrB_ALL indicator
                 return lib.GrB_ALL, size
             index = tuple(range(size)[index])
-        elif typ != list:
+        elif typ is not list:
             try:
                 index = tuple(index)
             except Exception:

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -5,11 +5,48 @@ from .ops import OpBase
 
 NULL = ffi.NULL
 
-# Sentinel object to indicate GrB_OUTP = GrB_REPLACE in the descriptor
-REPLACE = object()
+
+class Updater:
+    def __init__(self, parent, **kwargs):
+        self.parent = parent
+        self.kwargs = kwargs
+
+    def __getitem__(self, keys):
+        # Occurs when user calls C(params)[index]; need something prepared to receive `<<` or `.update()`
+        if self.parent.is_scalar:
+            raise TypeError('Indexing not supported for Scalars')
+        resolved_indexes = IndexerResolver(self.parent, keys)
+        return AmbiguousAssignOrExtract(self, resolved_indexes)
+
+    def __setitem__(self, keys, obj):
+        # Occurs when user calls C(params)[index] = delayed
+        if self.parent.is_scalar:
+            raise TypeError('Indexing not supported for Scalars')
+        if type(keys) == IndexerResolver:
+            resolved_indexes = keys
+        else:
+            resolved_indexes = IndexerResolver(self.parent, keys)
+
+        if resolved_indexes.is_single_element() and not self.kwargs:
+            # Fast path using assignElement
+            self.parent._assign_element(resolved_indexes, obj)
+        else:
+            delayed = self.parent._prep_for_assign(resolved_indexes, obj)
+            self.update(delayed)
+
+    def __lshift__(self, delayed):
+        # Occurs when user calls C(params) << delayed
+        self.parent._update(delayed, **self.kwargs)
+
+    def update(self, delayed):
+        # Occurs when user calls C(params).update(delayed)
+        self.parent._update(delayed, **self.kwargs)
 
 
 class GbContainer:
+    # Flag for operations which depend on scalar vs vector/matrix
+    is_scalar = False
+
     def __init__(self, gb_obj, dtype):
         if not isinstance(gb_obj, ffi.CData):
             raise TypeError('Object passed to __init__ must be CData type')
@@ -22,70 +59,138 @@ class GbContainer:
     def __invert__(self):
         return ComplementedMask(self)
 
+    def __delitem__(self, keys):
+        if self.is_scalar:
+            raise TypeError('Indexing not supported for Scalars')
+        raise NotImplementedError('Not available until GraphBLAS v1.3')
+
+    def __getitem__(self, keys):
+        if self.is_scalar:
+            raise TypeError('Indexing not supported for Scalars')
+        resolved_indexes = IndexerResolver(self, keys)
+        return AmbiguousAssignOrExtract(self, resolved_indexes)
+
     def __setitem__(self, keys, delayed):
+        Updater(self)[keys] = delayed
+
+    def __call__(self, *optional_mask_and_accum, mask=None, accum=None, replace=False):
+        # Pick out mask and accum from positional arguments
+        mask_arg, accum_arg = None, None
+        for key in optional_mask_and_accum:
+            if isinstance(key, GbContainer):
+                mask_arg = key
+            elif type(key) == ComplementedMask:
+                mask_arg = key
+            elif isinstance(key, ops.BinaryOp):
+                accum_arg = key
+            elif type(key) == ffi.CData and ops.find_opclass(key) != ops.UNKNOWN_OPCLASS:
+                accum_arg = key
+            else:
+                raise TypeError(f'Invalid item found in output params: {type(key)}')
+        # Merge positional and keyword arguments
+        if mask_arg is not None and mask is not None:
+            raise TypeError("got multiple values for argument 'mask'")
+        if mask_arg is not None:
+            mask = mask_arg
+        if mask is None:
+            mask = NULL
+        if accum_arg is not None and accum is not None:
+            raise TypeError("got multiple values for argument 'accum")
+        if accum_arg is not None:
+            accum = accum_arg
+        if accum is None:
+            accum = NULL
+        return Updater(self, mask=mask, accum=accum, replace=replace)
+
+    def __lshift__(self, delayed):
+        return self._update(delayed)
+
+    def update(self, delayed):
+        """
+        Convenience function when no output arguments (mask, accum, replace) are used
+        """
+        return self._update(delayed)
+
+    def _update(self, delayed, mask=NULL, accum=NULL, replace=False):
         # TODO: check expected output type (need to include in GbDelayed object)
         if not isinstance(delayed, GbDelayed):
             from .ops import UnaryOp
             from .matrix import Matrix, TransposedMatrix
-            if type(delayed) == self.__class__:
-                # Simple assignment (w[:] = v)
+            if type(delayed) == AmbiguousAssignOrExtract:
+                # Extract (C << A[rows, cols])
+                delayed = delayed._extract_delayed()
+            elif type(delayed) == self.__class__:
+                # Simple assignment (w << v)
                 delayed = delayed.apply(UnaryOp.IDENTITY)
             elif type(delayed) == TransposedMatrix and type(self) == Matrix:
-                # Transpose (C[:] = A.T)
+                # Transpose (C << A.T)
                 delayed = GbDelayed(lib.GrB_transpose, [delayed.gb_obj[0]])
             else:
                 raise TypeError(f'assignment value must be GbDelayed object, not {type(delayed)}')
-        if type(keys) != tuple:
-            keys = (keys,)
-        mask, accum, complement, replace = self._parse_keys(keys)
+
+        # Normalize mask and separate out complement flag
+        complement = False
+        if mask is NULL:
+            pass
+        elif isinstance(mask, GbContainer):
+            mask = mask.gb_obj[0]
+        elif type(mask) == ComplementedMask:
+            mask = mask.mask.gb_obj[0]
+            complement = True
+        else:
+            raise TypeError(f"Invalid mask: {type(mask)}")
+
+        # Normalize accumulator
+        if accum is NULL:
+            pass
+        elif isinstance(accum, ops.BinaryOp):
+            accum = accum[self.dtype]
+        elif type(accum) == ffi.CData and ops.find_opclass(accum) != ops.UNKNOWN_OPCLASS:
+            pass
+        else:
+            raise TypeError(f"Invalid accum: {type(accum)}")
+
+        # Build descriptor based on flags
         desc = descriptor.build(transpose_first=delayed.at,
                                 transpose_second=delayed.bt,
                                 mask_complement=complement,
                                 output_replace=replace)
+
         # Resolve any ops in tail_args
         tail_args = [x[self.dtype] if isinstance(x, OpBase) else x
                      for x in delayed.tail_args]
 
         # Build args and call GraphBLAS function
-        if self.can_mask:
-            call_args = [self.gb_obj[0], mask, accum] + tail_args + [desc]
-        else:
+        if self.is_scalar:
             if mask is not NULL:
-                raise TypeError('Mask not allowed')
+                raise TypeError('Mask not allowed for Scalars')
             call_args = [self.gb_obj, accum] + tail_args + [desc]
+            # Ensure the scalar isn't flagged as empty after the update
+            self.empty = False
+        else:
+            call_args = [self.gb_obj[0], mask, accum] + tail_args + [desc]
+
         # Make the GraphBLAS call
         check_status(delayed.func(*call_args))
 
-    def _parse_keys(self, keys):
-        """
-        Returns mask, accum, complement, replace based on the keys
-        """
-        mask = NULL
-        accum = NULL
-        complement = False
-        replace = False
+    def _extract_element(self, resolved_indexes):
+        raise TypeError(f'Cannot extract from {self.__class__.__name__}')
 
-        for key in keys:
-            if key is REPLACE:
-                replace = True
-            elif isinstance(key, GbContainer):
-                mask = key.gb_obj[0]
-            elif type(key) == ComplementedMask:
-                mask = key.mask.gb_obj[0]
-                complement = True
-            elif isinstance(key, slice):
-                if key == slice(None, None, None):
-                    continue
-                else:
-                    raise TypeError('Only the "ALL" slice [:] is allowed, to indicate no mask')
-            elif isinstance(key, ops.BinaryOp):
-                accum = key[self.dtype]
-            elif type(key) == ffi.CData and ops.find_opclass(key) != ops.UNKNOWN_OPCLASS:
-                accum = key
-            else:
-                raise TypeError(f'Invalid item found in output params: {type(key)}')
+    def _prep_for_extract(self, resolved_indexes):
+        raise TypeError(f'Cannot extract from {self.__class__.__name__}')
 
-        return mask, accum, complement, replace
+    def _assign_element(self, resolved_indexes, value):
+        raise TypeError(f'Cannot assign to {self.__class__.__name__}')
+
+    def _prep_for_assign(self, resolved_indexes, obj):
+        raise TypeError(f'Cannot assign to {self.__class__.__name__}')
+
+    @classmethod
+    def new_from_existing(cls, obj):
+        raise NotImplementedError()
+
+    def dup(self):
+        return type(self).new_from_existing(self)
 
     def show(self):
         from . import io
@@ -125,11 +230,126 @@ class GbDelayed:
         else:
             output = self.output_constructor()
         if mask is None:
-            mask = slice(None)  # [:] indicates no mask
-        elif not isinstance(mask, output.__class__):
-            raise TypeError(f'Mask must be type {output.__class__}')
-        output[mask] = self
+            output.update(self)
+        else:
+            if not isinstance(mask, output.__class__):
+                raise TypeError(f'Mask must be type {output.__class__}')
+            output(mask).update(self)
         return output
+
+
+class AmbiguousAssignOrExtract:
+    def __init__(self, parent, resolved_indexes):
+        self.parent = parent
+        self.resolved_indexes = resolved_indexes
+
+    def __call__(self, **kwargs):
+        # Occurs when user calls C[index](params)
+        # Upgrade self.parent to an Updater, then return self in preparation for `<<` or `.update()` call
+        self.parent = Updater(self.parent, **kwargs)
+        return self
+
+    def __lshift__(self, obj):
+        # Occurs when user calls C(params)[index] << obj or C[index] << obj
+        # Delegate back to parent's __setitem__ method
+        self.parent[self.resolved_indexes] = obj
+
+    def update(self, obj):
+        # Occurs when user calls C(params)[index].update(obj) or C[index].update(obj)
+        # Delegate back to parent's __setitem__ method
+        self.parent[self.resolved_indexes] = obj
+
+    @property
+    def value(self):
+        if isinstance(self.parent, Updater):
+            raise TypeError('Cannot extract from an Updater')
+        if not self.resolved_indexes.is_single_element():
+            raise AttributeError("Only Scalars have `.value` attribute")
+        val, _ = self.parent._extract_element(self.resolved_indexes)
+        return val
+
+    def new(self, *, dtype=None, mask=None):
+        """
+        Force extraction of the indexes into a new object
+        dtype and mask are the only controllable parameters.
+        """
+        if isinstance(self.parent, Updater):
+            raise TypeError('Cannot extract from an Updater')
+        if self.resolved_indexes.is_single_element():
+            if mask is not None:
+                raise TypeError('mask is not allowed for single element extraction')
+            val, cur_dtype = self.parent._extract_element(self.resolved_indexes)
+            if dtype is None:
+                dtype = cur_dtype
+            from .scalar import Scalar
+            return Scalar.new_from_value(val, dtype=dtype)
+        else:
+            delayed_extractor = self.parent._prep_for_extract(self.resolved_indexes)
+            return delayed_extractor.new(dtype=dtype, mask=mask)
+
+    def _extract_delayed(self):
+        """Return a GbDelayed object, treating this as an extract call"""
+        if isinstance(self.parent, Updater):
+            raise TypeError('Cannot extract from an Updater')
+        if self.resolved_indexes.is_single_element():
+            raise TypeError('extract and update is not allowed for single element')
+        return self.parent._prep_for_extract(self.resolved_indexes)
+
+
+class IndexerResolver:
+    def __init__(self, obj, indices):
+        if obj.is_scalar:
+            raise TypeError("Cannot index into Scalars")
+        self.obj = obj
+        self.indices = self.parse_indices(indices, obj.shape)
+
+    def is_single_element(self):
+        for idx, size in self.indices:
+            if size is not None:
+                return False
+        return True
+
+    def parse_indices(self, indices, shape):
+        """
+        Returns
+            [(rows, rowsize), (cols, colsize)] for Matrix
+            [(idx, idx_size)] for Vector
+
+        Within each tuple, if the index is of type int, the size will be None
+        """
+        if len(shape) == 1:
+            if type(indices) == tuple:
+                raise TypeError(f'Index for {self.obj.__class__.__name__} cannot be a tuple')
+            # Convert to tuple for consistent processing
+            indices = (indices,)
+        elif len(shape) == 2:
+            if type(indices) != tuple or len(indices) != 2:
+                raise TypeError(f'Index for {self.obj.__class__.__name__} must be a 2-tuple')
+
+        out = []
+        for i, idx in enumerate(indices):
+            typ = type(idx)
+            if type == tuple:
+                raise TypeError(f'Index in position {i} cannot be a tuple; must use slice or list or int')
+            out.append(self.parse_index(idx, typ, shape[i]))
+        return out
+
+    def parse_index(self, index, typ, size):
+        if typ == int:
+            if index >= size:
+                raise IndexError(f'index={index}, size={size}')
+            return index, None
+        if typ == slice:
+            if index == slice(None):
+                # [:] means all indices; use special GrB_ALL indicator
+                return lib.GrB_ALL, size
+            index = tuple(range(size)[index])
+        elif typ != list:
+            try:
+                index = tuple(index)
+            except Exception:
+                raise TypeError('Unable to convert to tuple')
+        return ffi.new('GrB_Index[]', index), len(index)
 
 
 class ComplementedMask:

--- a/grblas/descriptor.py
+++ b/grblas/descriptor.py
@@ -5,7 +5,7 @@ _desc_map = {}
 
 
 # TODO: this will need to update for GraphBLAS 1.3 mask options
-def build(*, output_replace=False, mask_complement=False, 
+def build(*, output_replace=False, mask_complement=False,
           transpose_first=False, transpose_second=False):
     key = (mask_complement, output_replace, transpose_first, transpose_second)
     if key not in _desc_map:

--- a/grblas/dtypes.py
+++ b/grblas/dtypes.py
@@ -1,7 +1,6 @@
 import re
 from . import lib
 import numba
-import numpy as np
 
 
 class DataType:
@@ -12,13 +11,13 @@ class DataType:
         self.gb_type = gb_type
         self.c_type = c_type
         self.numba_type = numba_type
-    
+
     def __repr__(self):
         return self.name
-    
+
     def __hash__(self):
         return hash((self.name, self.c_type))
-    
+
     def __eq__(self, other):
         if isinstance(other, DataType):
             return self.gb_type == other.gb_type
@@ -29,7 +28,7 @@ class DataType:
                 return self == other
             except KeyError:
                 return False
-    
+
     @classmethod
     def from_pytype(cls, pytype):
         if pytype is int:

--- a/grblas/exceptions.py
+++ b/grblas/exceptions.py
@@ -4,6 +4,7 @@ from . import lib, ffi
 class GrblasException(Exception):
     pass
 
+
 if lib is None or ffi is None:
     raise GrblasException('grblas must be initialized with the backend prior to use; call `grblas.init(backend)`')
 

--- a/grblas/io.py
+++ b/grblas/io.py
@@ -21,8 +21,8 @@ def show(m):
         for i, val in zip(*m.to_values()):
             df.iloc[i] = val
         df = df.where(pd.notnull(df), '').T
-    elif isinstance(m, Scalar):
-        df = m.value
+    # elif isinstance(m, Scalar):
+    #     df = m.value
     else:
         return
 

--- a/grblas/io.py
+++ b/grblas/io.py
@@ -1,5 +1,4 @@
-import numpy as np
-from . import Matrix, Vector, Scalar, dtypes
+from . import Matrix, Vector, dtypes
 from .exceptions import GrblasException
 
 
@@ -116,7 +115,7 @@ def to_networkx(m):
 
 def to_numpy(m, format='array'):
     try:
-        from scipy.sparse import coo_matrix
+        import scipy  # noqa
     except ImportError:
         raise ImportError('scipy is required to export to numpy')
 

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -1,10 +1,8 @@
-import types
 from functools import partial
 from .base import lib, ffi, NULL, GbContainer, GbDelayed
 from .vector import Vector
 from .scalar import Scalar
-from .ops import (OpBase, UnaryOp, BinaryOp, Monoid, Semiring,
-                  find_opclass, find_return_type)
+from .ops import BinaryOp, Monoid, Semiring, find_opclass, find_return_type
 from . import dtypes
 from .exceptions import check_status, is_error, NoValue
 
@@ -19,7 +17,7 @@ class Matrix(GbContainer):
 
     def __del__(self):
         check_status(lib.GrB_Matrix_free(self.gb_obj))
-    
+
     def __repr__(self):
         return f'<Matrix {self.nvals}/({self.nrows}x{self.ncols}):{self.dtype.name}>'
 
@@ -141,7 +139,7 @@ class Matrix(GbContainer):
             dup_op))
         # Check for duplicates when dup_op was not provided
         if dup_orig is NULL and self.nvals < len(values):
-            raise ValueError('Duplicate indices found, must provide `dup_op` BinaryOp') 
+            raise ValueError('Duplicate indices found, must provide `dup_op` BinaryOp')
 
     @classmethod
     def new_from_type(cls, dtype, nrows=0, ncols=0):
@@ -199,7 +197,7 @@ class Matrix(GbContainer):
 
     #########################################################
     # Delayed methods
-    # 
+    #
     # These return a GbDelayed object which must be passed
     # to __setitem__ to trigger a call to GraphBLAS
     #########################################################
@@ -366,14 +364,14 @@ class Matrix(GbContainer):
                          [op, self.gb_obj[0]],
                          at=self.is_transposed,
                          output_constructor=output_constructor)
-    
+
     def reduce_columns(self, op=NULL):
         """
         GrB_Matrix_reduce
         Reduce all values in each column, converting the matrix to a vector
         """
         return self.T.reduce_rows(op)
-    
+
     def reduce_scalar(self, op=NULL):
         """
         GrB_Matrix_reduce
@@ -388,8 +386,8 @@ class Matrix(GbContainer):
         output_constructor = partial(Scalar.new_from_type,
                                      dtype=find_return_type(op, self.dtype))
         return GbDelayed(func,
-                        [op, self.gb_obj[0]],
-                        output_constructor=output_constructor)
+                         [op, self.gb_obj[0]],
+                         output_constructor=output_constructor)
 
     ##################################
     # Extract and Assign index methods
@@ -503,7 +501,7 @@ class TransposedMatrix(Matrix):
         super().__init__(matrix.gb_obj, matrix.dtype)
         self._matrix = matrix
 
-    # Override the default behavior. Don't free gb_obj 
+    # Override the default behavior. Don't free gb_obj
     # because it's shared with the untransposed matrix
     def __del__(self):
         pass
@@ -532,7 +530,7 @@ class TransposedMatrix(Matrix):
     @property
     def T(self):
         return self._matrix
-    
+
     @property
     def is_transposed(self):
         return True

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -25,7 +25,7 @@ class Matrix(GbContainer):
 
     def __eq__(self, other):
         # Borrowed this recipe from LAGraph
-        if type(other) != self.__class__:
+        if type(other) is not self.__class__:
             return False
         if self.dtype != other.dtype:
             return False
@@ -516,7 +516,7 @@ class TransposedMatrix(Matrix):
         if mask is None:
             output.update(self)
         else:
-            if type(mask) != Matrix:
+            if type(mask) is not Matrix:
                 raise TypeError('Mask must be a Matrix')
             output(mask).update(self)
         return output

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -14,13 +14,8 @@ class Matrix(GbContainer):
     GraphBLAS Sparse Matrix
     High-level wrapper around GrB_Matrix type
     """
-    can_mask = True
-
     def __init__(self, gb_obj, dtype):
         super().__init__(gb_obj, dtype)
-        self.element = Matrix.ElementManipulator(self)
-        self.extract = Matrix.Extractor(self)
-        self.assign = Matrix.Assigner(self)
 
     def __del__(self):
         check_status(lib.GrB_Matrix_free(self.gb_obj))
@@ -42,12 +37,12 @@ class Matrix(GbContainer):
             return False
         # Use ewise_mult to compare equality via intersection
         matches = Matrix.new_from_type(bool, self.nrows, self.ncols)
-        matches[:] = self.ewise_mult(other, BinaryOp.EQ)
+        matches << self.ewise_mult(other, BinaryOp.EQ)
         if matches.nvals != self.nvals:
             return False
         # Check if all results are True
         result = Scalar.new_from_type(bool)
-        result[:] = matches.reduce_scalar(Monoid.LAND)
+        result << matches.reduce_scalar(Monoid.LAND)
         return result.value
 
     def __len__(self):
@@ -110,7 +105,7 @@ class Matrix(GbContainer):
             values,
             n,
             self.gb_obj[0]))
-        return iter(rows), iter(columns), iter(values)
+        return tuple(rows), tuple(columns), tuple(values)
 
     def rebuild_from_values(self, rows, columns, values, *, dup_op=NULL):
         # TODO: add `size` option once .resize is available
@@ -326,11 +321,7 @@ class Matrix(GbContainer):
         A BinaryOp can also be applied if a scalar is passed in as `left` or `right`,
             effectively converting a BinaryOp into a UnaryOp
         """
-        if isinstance(op, types.FunctionType):
-            op = build_udf(op, self)
-            opclass = 'UnaryOp'
-        else:
-            opclass = find_opclass(op)
+        opclass = find_opclass(op)
 
         if opclass == 'UnaryOp':
             if left is not None or right is not None:
@@ -400,217 +391,118 @@ class Matrix(GbContainer):
                         [op, self.gb_obj[0]],
                         output_constructor=output_constructor)
 
+    ##################################
+    # Extract and Assign index methods
+    ##################################
+    def _extract_element(self, resolved_indexes):
+        row, _ = resolved_indexes.indices[0]
+        col, _ = resolved_indexes.indices[1]
+        func = getattr(lib, f'GrB_Matrix_extractElement_{self.dtype}')
+        result = ffi.new(f'{self.dtype.c_type}*')
 
-    class ElementManipulator:
-        def __init__(self, matrix):
-            self._matrix = matrix
-        
-        def __repr__(self):
-            return 'MatrixElementManipulator'
-        
-        def _parse_index(self, index):
-            if (
-                not isinstance(index, tuple)
-                or len(index) != 2
-                or not isinstance(index[0], int)
-                or not isinstance(index[1], int)
-            ):
-                raise TypeError('Index must be a 2-tuple of ints')
-            row, col = index
-            shape = self._matrix.shape
-            if row >= shape[0]:
-                raise IndexError(f'row_index={row}, nrows={shape[0]}')
-            if col >= shape[1]:
-                raise IndexError(f'col_index={col}, ncols={shape[1]}')
-            return row, col
+        err_code = func(result,
+                        self.gb_obj[0],
+                        row,
+                        col)
+        # Don't raise error for no value, simply return `None`
+        if is_error(err_code, NoValue):
+            return None, self.dtype
+        check_status(err_code)
+        return result[0], self.dtype
 
-        def __getitem__(self, index):
-            row, col = self._parse_index(index)
-            mat = self._matrix
-            func = getattr(lib, f'GrB_Matrix_extractElement_{mat.dtype}')
-            result = ffi.new(f'{mat.dtype.c_type}*')
-            err_code = func(result,
-                            mat.gb_obj[0],
-                            row,
-                            col)
-            # If no value, return Python `None`
-            if is_error(err_code, NoValue):
-                return None
-            check_status(err_code)
-            return result[0]
-        
-        def __setitem__(self, index, value):
-            row, col = self._parse_index(index)
-            mat = self._matrix
-            func = getattr(lib, f'GrB_Matrix_setElement_{mat.dtype}')
-            check_status(func(
-                mat.gb_obj[0],
-                ffi.cast(mat.dtype.c_type, value),
-                row,
-                col))
+    def _prep_for_extract(self, resolved_indexes):
+        rows, rowsize = resolved_indexes.indices[0]
+        cols, colsize = resolved_indexes.indices[1]
+        if rowsize is None:
+            # Row-only selection; GraphBLAS doesn't have this method, so we hack it using transpose
+            row_index = rows
+            output_constructor = partial(Vector.new_from_type,
+                                         dtype=self.dtype,
+                                         size=colsize)
+            return GbDelayed(lib.GrB_Col_extract,
+                             [self.gb_obj[0], cols, colsize, row_index],
+                             at=(not self.is_transposed),
+                             output_constructor=output_constructor)
+        elif colsize is None:
+            # Column-only selection
+            col_index = cols
+            output_constructor = partial(Vector.new_from_type,
+                                         dtype=self.dtype,
+                                         size=rowsize)
+            return GbDelayed(lib.GrB_Col_extract,
+                             [self.gb_obj[0], rows, rowsize, col_index],
+                             at=self.is_transposed,
+                             output_constructor=output_constructor)
+        else:
+            output_constructor = partial(Matrix.new_from_type,
+                                         dtype=self.dtype,
+                                         nrows=rowsize, ncols=colsize)
+            return GbDelayed(lib.GrB_Matrix_extract,
+                             [self.gb_obj[0], rows, rowsize, cols, colsize],
+                             at=self.is_transposed,
+                             output_constructor=output_constructor)
 
-        def __delitem__(self, index):
-            row, col = self._parse_index(index)
-            raise NotImplementedError('Not available in GraphBLAS 1.2')
+    def _assign_element(self, resolved_indexes, value):
+        row, _ = resolved_indexes.indices[0]
+        col, _ = resolved_indexes.indices[1]
+        func = getattr(lib, f'GrB_Matrix_setElement_{self.dtype}')
+        check_status(func(
+                     self.gb_obj[0],
+                     ffi.cast(self.dtype.c_type, value),
+                     row,
+                     col))
 
-    class _Indexer:
-        def _parse_indices(self, indices):
-            """
-            Returns rows, rowsize, cols, colsize
-            For row-only, rowsize=None and type(rows)==int
-            For col-only, colsize=None and type(cols)==int
-            """
-            if type(indices) != tuple or len(indices) != 2:
-                raise TypeError('Index must be a 2-tuple')
-            rows, cols = indices
-            rtyp, ctyp = type(rows), type(cols)
-            
-            if rtyp == int and ctyp == int:
-                # Single index
-                return rows, None, cols, None
-            if rtyp == tuple or ctyp == tuple:
-                raise TypeError(f'{self} cannot accept a tuple as index; use slice or list')
+    def _prep_for_assign(self, resolved_indexes, obj):
+        rows, rowsize = resolved_indexes.indices[0]
+        cols, colsize = resolved_indexes.indices[1]
 
-            rows, rowsize = self._parse_index(rows, rtyp, self._matrix.nrows)
-            cols, colsize = self._parse_index(cols, ctyp, self._matrix.ncols)
-            return rows, rowsize, cols, colsize
+        if isinstance(obj, Scalar):
+            obj = obj.value
 
-        def _parse_index(self, index, typ, size):
-            if typ == int:
-                return index, None
-            if typ == slice:
-                if index == slice(None):
-                    # [:] means all indices; use special GrB_ALL indicator
-                    return lib.GrB_ALL, size
-                index = tuple(range(size)[index])
-            elif typ != list:
-                try:
-                    index = tuple(index)
-                except Exception:
-                    raise TypeError()
-            return ffi.new('GrB_Index[]', index), len(index)
-
-    class Extractor(_Indexer):
-        def __init__(self, matrix):
-            self._matrix = matrix
-        
-        def __repr__(self):
-            return 'MatrixExtractor'
-        
-        def __getitem__(self, indices):
-            rows, rowsize, cols, colsize = self._parse_indices(indices)
-            if rowsize is None and colsize is None:
-                raise TypeError('Use A.element[i, j] to get a single element')
+        if isinstance(obj, (int, float, bool)):
             if rowsize is None:
-                # Row-only selection; GraphBLAS doesn't have this method, so we hack it using transpose
+                rows = [rows]
+                rowsize = 1
+            if colsize is None:
+                cols = [cols]
+                colsize = 1
+            dtype = self.dtype
+            scalar = ffi.cast(dtype.c_type, obj)
+            func = getattr(lib, f'GrB_Matrix_assign_{dtype.name}')
+            delayed = GbDelayed(func,
+                                [scalar, rows, rowsize, cols, colsize])
+        else:
+            if rowsize is None and colsize is None:
+                raise TypeError(f'Expected scalar for assignment value; found {type(obj)}')
+            elif rowsize is None:
+                if not isinstance(obj, Vector):
+                    raise TypeError(f'Expected Vector for assignment value; found {type(obj)}')
+                # Row-only selection
                 row_index = rows
-                output_constructor = partial(Vector.new_from_type,
-                                             dtype=self._matrix.dtype,
-                                             size=colsize)
-                return GbDelayed(lib.GrB_Col_extract,
-                                 [self._matrix.gb_obj[0], cols, colsize, row_index],
-                                 at=(not self._matrix.is_transposed),
-                                 output_constructor=output_constructor)
+                delayed = GbDelayed(lib.GrB_Row_assign,
+                                    [obj.gb_obj[0], row_index, cols, colsize])
             elif colsize is None:
+                if not isinstance(obj, Vector):
+                    raise TypeError(f'Expected Vector for assignment value; found {type(obj)}')
                 # Column-only selection
                 col_index = cols
-                output_constructor = partial(Vector.new_from_type,
-                                             dtype=self._matrix.dtype,
-                                             size=rowsize)
-                return GbDelayed(lib.GrB_Col_extract,
-                                 [self._matrix.gb_obj[0], rows, rowsize, col_index],
-                                 at=self._matrix.is_transposed,
-                                 output_constructor=output_constructor)
+                delayed = GbDelayed(lib.GrB_Col_assign,
+                                    [obj.gb_obj[0], rows, rowsize, col_index])
             else:
-                output_constructor = partial(Matrix.new_from_type,
-                                             dtype=self._matrix.dtype,
-                                             nrows=rowsize, ncols=colsize)
-                return GbDelayed(lib.GrB_Matrix_extract,
-                                 [self._matrix.gb_obj[0], rows, rowsize, cols, colsize],
-                                 at=self._matrix.is_transposed,
-                                 output_constructor=output_constructor)
-    
-    class Assigner(_Indexer):
-        def __init__(self, matrix):
-            self._matrix = matrix
-        
-        def __repr__(self):
-            return 'MatrixAssigner'
-        
-        def __setitem__(self, keys, other):
-            # Note: keys contains assignment rows, cols, mask, accum, and REPLACE
-            #       rows, cols must always come first (if given, otherwise assumes all indexes)
-            #       C.assign[:] will be interpreted as all indexes with no mask
-            if type(keys) != tuple:
-                keys = (keys,)
-            if len(keys) >= 2:
-                try:
-                    # Try to parse the first two items as the row/col indexes
-                    rows, rowsize, cols, colsize = self._parse_indices(keys[:2])
-                    keys = keys[2:]
-                except TypeError:
-                    # No index given; use the default
-                    rows, rowsize, cols, colsize = self._parse_indices((slice(None), slice(None)))
-            else:
-                # No index given; use the default
-                rows, rowsize, cols, colsize = self._parse_indices((slice(None), slice(None)))
-            if not keys or (len(keys) == 1 and keys[0] == slice(None)):
-                # No keys given; use the default
-                keys = slice(None)
-            else:
-                for key in keys:
-                    if type(key) in (list, slice):
-                        raise TypeError('Assignment indexes for rows and columns must come first')
+                if not isinstance(obj, Matrix):
+                    raise TypeError(f'Expected Matrix for assignment value; found {type(obj)}')
+                delayed = GbDelayed(lib.GrB_Matrix_assign,
+                                    [obj.gb_obj[0], rows, rowsize, cols, colsize],
+                                    at=obj.is_transposed)
 
-            if isinstance(other, Scalar):
-                other = other.value
+        return delayed
 
-            if isinstance(other, (int, float, bool)):
-                if rowsize is None:
-                    rows = [rows]
-                    rowsize = 1
-                if colsize is None:
-                    cols = [cols]
-                    colsize = 1
-                dtype = self._matrix.dtype
-                scalar = ffi.cast(dtype.c_type, other)
-                func = getattr(lib, f'GrB_Matrix_assign_{dtype.name}')
-                dval = GbDelayed(func,
-                                 [scalar, rows, rowsize, cols, colsize])
-            else:
-                if rowsize is None and colsize is None:
-                    raise TypeError(f'Expected scalar for assignment value; found {type(other)}')
-                elif rowsize is None:
-                    if not isinstance(other, Vector):
-                        raise TypeError(f'Expected Vector for assignment value; found {type(other)}')
-                    # Row-only selection
-                    row_index = rows
-                    dval = GbDelayed(lib.GrB_Row_assign,
-                                    [other.gb_obj[0], row_index, cols, colsize])
-                elif colsize is None:
-                    if not isinstance(other, Vector):
-                        raise TypeError(f'Expected Vector for assignment value; found {type(other)}')
-                    # Column-only selection
-                    col_index = cols
-                    dval = GbDelayed(lib.GrB_Col_assign,
-                                    [other.gb_obj[0], rows, rowsize, col_index])
-                else:
-                    if not isinstance(other, Matrix):
-                        raise TypeError(f'Expected Matrix for assignment value; found {type(other)}')
-                    dval = GbDelayed(lib.GrB_Matrix_assign,
-                                        [other.gb_obj[0], rows, rowsize, cols, colsize],
-                                        at=other.is_transposed)
-            # Forward the __setitem__ call so it is resolved with mask and accum
-            self._matrix[keys] = dval
 
 class TransposedMatrix(Matrix):
     def __init__(self, matrix):
         super().__init__(matrix.gb_obj, matrix.dtype)
         self._matrix = matrix
-        # Remove items that aren't allowed to be accessed post-transpose
-        del self.element
-        del self.assign
-    
+
     # Override the default behavior. Don't free gb_obj 
     # because it's shared with the untransposed matrix
     def __del__(self):
@@ -620,12 +512,13 @@ class TransposedMatrix(Matrix):
         return f'<Matrix.T {self.nvals}/({self.nrows}x{self.ncols}):{self.dtype.name}>'
 
     def new(self, mask=None):
-        if mask is None:
-            mask = slice(None)  # [:] indicates no mask
-        elif type(mask) != Matrix:
-            raise TypeError('Mask must be a Matrix')
         output = Matrix.new_from_type(self.dtype, self.nrows, self.ncols)
-        output[mask] = self
+        if mask is None:
+            output.update(self)
+        else:
+            if type(mask) != Matrix:
+                raise TypeError('Mask must be a Matrix')
+            output(mask).update(self)
         return output
 
     @property

--- a/grblas/ops.py
+++ b/grblas/ops.py
@@ -95,7 +95,7 @@ class UnaryOp(OpBase):
 
     @classmethod
     def register_new(cls, name, func):
-        if type(func) != FunctionType:
+        if type(func) is not FunctionType:
             raise TypeError(f'udf must be a function, not {type(func)}')
         if hasattr(cls, name):
             raise AttributeError(f'UnaryOp.{name} is already defined')
@@ -105,7 +105,7 @@ class UnaryOp(OpBase):
             # Check if func can handle this data type
             try:
                 ret = func(sample_val)
-                if type(ret) == bool:
+                if type(ret) is bool:
                     ret_type = dtypes.BOOL
                 elif type_ == 'BOOL':
                     # type_ == bool, but return type != bool; invalid
@@ -154,7 +154,7 @@ class BinaryOp(OpBase):
 
     @classmethod
     def register_new(cls, name, func):
-        if type(func) != FunctionType:
+        if type(func) is not FunctionType:
             raise TypeError(f'udf must be a function, not {type(func)}')
         if hasattr(cls, name):
             raise AttributeError(f'UnaryOp.{name} is already defined')
@@ -164,7 +164,7 @@ class BinaryOp(OpBase):
             # Check if func can handle this data type
             try:
                 ret = func(sample_val, sample_val)
-                if type(ret) == bool:
+                if type(ret) is bool:
                     ret_type = dtypes.BOOL
                 elif type_ == 'BOOL':
                     # type_ == bool, but return type != bool; invalid
@@ -211,7 +211,7 @@ class Monoid(OpBase):
 
     @classmethod
     def register_new(cls, name, binaryop, zero):
-        if type(binaryop) != BinaryOp:
+        if type(binaryop) is not BinaryOp:
             raise TypeError(f'binaryop must be a BinaryOp, not {type(binaryop)}')
         new_type_obj = cls(name)
         for type_ in binaryop.types:
@@ -241,7 +241,7 @@ class Semiring(OpBase):
 
     @classmethod
     def register_new(cls, name, monoid, binaryop):
-        if type(monoid) != Monoid:
+        if type(monoid) is not Monoid:
             raise TypeError(f'monoid must be a Monoid, not {type(monoid)}')
         if type(binaryop) != BinaryOp:
             raise TypeError(f'binaryop must be a BinaryOp, not {type(binaryop)}')

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -1,9 +1,4 @@
-from .base import (
-    lib,
-    ffi,
-    NULL,
-    GbContainer,
-)
+from .base import ffi, GbContainer
 from . import dtypes
 
 
@@ -16,7 +11,7 @@ class Scalar(GbContainer):
 
     def __init__(self, gb_obj, dtype, empty=False):
         super().__init__(gb_obj, dtype)
-        self.empty = empty
+        self.is_empty = empty
 
     def __repr__(self):
         return f'<Scalar {self.value}:{self.dtype}>'
@@ -30,7 +25,7 @@ class Scalar(GbContainer):
             return self.value == other
 
     def __bool__(self):
-        if self.empty:
+        if self.is_empty:
             return False
         return bool(self.value)
 
@@ -39,11 +34,11 @@ class Scalar(GbContainer):
             self.value = False
         else:
             self.value = 0
-        self.empty = True
+        self.is_empty = True
 
     @property
     def value(self):
-        if self.empty:
+        if self.is_empty:
             return None
         return self.gb_obj[0]
 
@@ -53,7 +48,7 @@ class Scalar(GbContainer):
             self.clear()
         else:
             self.gb_obj[0] = val
-            self.empty = False
+            self.is_empty = False
 
     @classmethod
     def new_from_type(cls, dtype):

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -22,7 +22,7 @@ class Scalar(GbContainer):
         return f'<Scalar {self.value}:{self.dtype}>'
 
     def __eq__(self, other):
-        if type(other) == Scalar:
+        if type(other) is Scalar:
             if self.dtype != other.dtype:
                 return False
             return self.value == other.value

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -1,9 +1,7 @@
-import types
 from functools import partial
 from .base import lib, ffi, NULL, GbContainer, GbDelayed
 from .scalar import Scalar
-from .ops import (OpBase, UnaryOp, BinaryOp, Monoid, Semiring,
-                  find_opclass, find_return_type)
+from .ops import BinaryOp, Monoid, Semiring, find_opclass, find_return_type
 from . import dtypes
 from .exceptions import check_status, is_error, NoValue
 
@@ -18,7 +16,7 @@ class Vector(GbContainer):
 
     def __del__(self):
         check_status(lib.GrB_Vector_free(self.gb_obj))
-    
+
     def __repr__(self):
         return f'<Vector {self.nvals}/{self.size}:{self.dtype.name}>'
 
@@ -63,7 +61,7 @@ class Vector(GbContainer):
 
     def clear(self):
         check_status(lib.GrB_Vector_clear(self.gb_obj[0]))
-    
+
     def resize(self, size):
         raise NotImplementedError('Not implemented in GraphBLAS 1.2')
         check_status(lib.GrB_Vector_resize(self.gb_obj[0], size))
@@ -115,7 +113,7 @@ class Vector(GbContainer):
             dup_op))
         # Check for duplicates when dup_op was not provided
         if dup_orig is NULL and self.nvals < len(values):
-            raise ValueError('Duplicate indices found, must provide `dup_op` BinaryOp') 
+            raise ValueError('Duplicate indices found, must provide `dup_op` BinaryOp')
 
     @classmethod
     def new_from_type(cls, dtype, size=0):
@@ -166,7 +164,7 @@ class Vector(GbContainer):
 
     #########################################################
     # Delayed methods
-    # 
+    #
     # These return a GbDelayed object which must be passed
     # to update to trigger a call to GraphBLAS
     #########################################################
@@ -277,8 +275,8 @@ class Vector(GbContainer):
         output_constructor = partial(Scalar.new_from_type,
                                      dtype=find_return_type(op, self.dtype))
         return GbDelayed(func,
-                        [op, self.gb_obj[0]],
-                        output_constructor=output_constructor)
+                         [op, self.gb_obj[0]],
+                         output_constructor=output_constructor)
 
     ##################################
     # Extract and Assign index methods

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -24,7 +24,7 @@ class Vector(GbContainer):
 
     def __eq__(self, other):
         # Borrowed this recipe from LAGraph
-        if type(other) != self.__class__:
+        if type(other) is not self.__class__:
             return False
         if self.dtype != other.dtype:
             return False

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -13,13 +13,8 @@ class Vector(GbContainer):
     GraphBLAS Sparse Vector
     High-level wrapper around GrB_Vector type
     """
-    can_mask = True
-
     def __init__(self, gb_obj, dtype):
         super().__init__(gb_obj, dtype)
-        self.element = Vector.ElementManipulator(self)
-        self.extract = Vector.Extractor(self)
-        self.assign = Vector.Assigner(self)
 
     def __del__(self):
         check_status(lib.GrB_Vector_free(self.gb_obj))
@@ -39,12 +34,12 @@ class Vector(GbContainer):
             return False
         # Use ewise_mult to compare equality via intersection
         matches = Vector.new_from_type(bool, self.size)
-        matches[:] = self.ewise_mult(other, BinaryOp.EQ)
+        matches << self.ewise_mult(other, BinaryOp.EQ)
         if matches.nvals != self.nvals:
             return False
         # Check if all results are True
         result = Scalar.new_from_type(bool)
-        result[:] = matches.reduce(Monoid.LAND)
+        result << matches.reduce(Monoid.LAND)
         return result.value
 
     def __len__(self):
@@ -88,7 +83,7 @@ class Vector(GbContainer):
             values,
             n,
             self.gb_obj[0]))
-        return (iter(indices), iter(values))
+        return tuple(indices), tuple(values)
 
     def rebuild_from_values(self, indices, values, *, dup_op=NULL):
         # TODO: add `size` option once .resize is available
@@ -173,7 +168,7 @@ class Vector(GbContainer):
     # Delayed methods
     # 
     # These return a GbDelayed object which must be passed
-    # to __setitem__ to trigger a call to GraphBLAS
+    # to update to trigger a call to GraphBLAS
     #########################################################
 
     def ewise_add(self, other, op=NULL):
@@ -285,132 +280,56 @@ class Vector(GbContainer):
                         [op, self.gb_obj[0]],
                         output_constructor=output_constructor)
 
-    class ElementManipulator:
-        def __init__(self, vector):
-            self._vector = vector
-        
-        def __repr__(self):
-            return 'VectorElementManipulator'
-        
-        def _parse_index(self, index):
-            if not isinstance(index, int):
-                raise TypeError('Index must be an int')
-            size = self._vector.size
-            if index >= size:
-                raise IndexError(f'index={index}, size={size}')
-            return index
+    ##################################
+    # Extract and Assign index methods
+    ##################################
+    def _extract_element(self, resolved_indexes):
+        index, _ = resolved_indexes.indices[0]
+        func = getattr(lib, f'GrB_Vector_extractElement_{self.dtype}')
+        result = ffi.new(f'{self.dtype.c_type}*')
 
-        def __getitem__(self, index):
-            index = self._parse_index(index)
-            vec = self._vector
-            func = getattr(lib, f'GrB_Vector_extractElement_{vec.dtype}')
-            result = ffi.new(f'{vec.dtype.c_type}*')
+        err_code = func(result,
+                        self.gb_obj[0],
+                        index)
+        # Don't raise error for no value, simply return `None`
+        if is_error(err_code, NoValue):
+            return None, self.dtype
+        check_status(err_code)
+        return result[0], self.dtype
 
-            err_code = func(result,
-                            vec.gb_obj[0],
-                            index)
-            # Don't raise error for no value, simply return `None`
-            if is_error(err_code, NoValue):
-                return None
-            check_status(err_code)
-            return result[0]
-        
-        def __setitem__(self, index, value):
-            index = self._parse_index(index)
-            vec = self._vector
-            func = getattr(lib, f'GrB_Vector_setElement_{vec.dtype}')
-            check_status(func(
-                vec.gb_obj[0],
-                ffi.cast(vec.dtype.c_type, value),
-                index))
+    def _prep_for_extract(self, resolved_indexes):
+        index, isize = resolved_indexes.indices[0]
+        output_constructor = partial(Vector.new_from_type,
+                                     dtype=self.dtype,
+                                     size=isize)
+        return GbDelayed(lib.GrB_Vector_extract,
+                         [self.gb_obj[0], index, isize],
+                         output_constructor=output_constructor)
 
-        def __delitem__(self, index):
-            index = self._parse_index(index)
-            raise NotImplementedError('Not available in GraphBLAS 1.2')
+    def _assign_element(self, resolved_indexes, value):
+        index, _ = resolved_indexes.indices[0]
+        func = getattr(lib, f'GrB_Vector_setElement_{self.dtype}')
+        check_status(func(
+                     self.gb_obj[0],
+                     ffi.cast(self.dtype.c_type, value),
+                     index))
 
-    class _Indexer:
-        def _parse_index(self, index):
-            typ = type(index)
-            if typ == int:
-                # Single index
-                return index, None
-            if typ == tuple:
-                raise TypeError(f'{self} cannot accept a tuple as index; use slice or list')
-            if typ == slice:
-                if index == slice(None):
-                    # [:] means all indices; use special GrB_ALL indicator
-                    return lib.GrB_ALL, self._vector.size
-                index = tuple(range(self._vector.size)[index])
-            elif typ != list:
-                try:
-                    index = tuple(index)
-                except Exception:
-                    raise TypeError()
-            return ffi.new('GrB_Index[]', index), len(index)
+    def _prep_for_assign(self, resolved_indexes, obj):
+        index, isize = resolved_indexes.indices[0]
 
-    class Extractor(_Indexer):
-        def __init__(self, vector):
-            self._vector = vector
-        
-        def __repr__(self):
-            return 'VectorExtractor'
-        
-        def __getitem__(self, index):
-            index, isize = self._parse_index(index)
-            if isize is None:
-                raise TypeError('Use v.element[i] to get a single element')
-            output_constructor = partial(Vector.new_from_type,
-                                         dtype=self._vector.dtype,
-                                         size=isize)
-            return GbDelayed(lib.GrB_Vector_extract,
-                            [self._vector.gb_obj[0], index, isize],
-                            output_constructor=output_constructor)
-    
-    class Assigner(_Indexer):
-        def __init__(self, vector):
-            self._vector = vector
-        
-        def __repr__(self):
-            return 'VectorAssigner'
-        
-        def __setitem__(self, keys, other):
-            # Note: keys contains assignment index, mask, accum, and REPLACE
-            #       index must always come first (if given, otherwise assumes all indexes)
-            #       v.assign[:] will be interpreted as all indexes with no mask
-            if type(keys) != tuple:
-                keys = (keys,)
-            try:
-                # Try to parse the first item as an index
-                index, isize = self._parse_index(keys[0])
-                keys = keys[1:]
-                if isize is None:
-                    # We have a single index; convert to a len=1 list
-                    index = [index]
-                    isize = 1
-            except TypeError:
-                # No index given; use the default
-                index, isize = self._parse_index(slice(None))
-            if not keys:
-                # No keys given; use the default
-                keys = slice(None)
-            else:
-                for key in keys:
-                    if type(key) in (list, slice):
-                        raise TypeError('Assignment indexes must come first')
+        if isinstance(obj, Scalar):
+            obj = obj.value
 
-            if isinstance(other, Scalar):
-                other = other.value
+        if isinstance(obj, (int, float, bool)):
+            dtype = self.dtype
+            func = getattr(lib, f'GrB_Vector_assign_{dtype.name}')
+            scalar = ffi.cast(dtype.c_type, obj)
+            delayed = GbDelayed(func,
+                                [scalar, index, isize])
+        elif isinstance(obj, Vector):
+            delayed = GbDelayed(lib.GrB_Vector_assign,
+                                [obj.gb_obj[0], index, isize])
+        else:
+            raise TypeError(f'Unexpected type for assignment value: {type(obj)}')
 
-            if isinstance(other, (int, float, bool)):
-                dtype = self._vector.dtype
-                func = getattr(lib, f'GrB_Vector_assign_{dtype.name}')
-                scalar = ffi.cast(dtype.c_type, other)
-                dval = GbDelayed(func,
-                                 [scalar, index, isize])
-            elif isinstance(other, Vector):
-                dval = GbDelayed(lib.GrB_Vector_assign,
-                                 [other.gb_obj[0], index, isize])
-            else:
-                raise TypeError(f'Unexpected type for assignment value: {type(other)}')
-            # Forward the __setitem__ call so it is resolved with mask and accum
-            self._vector[keys] = dval
+        return delayed

--- a/notebooks/Example B.1 -- Level BFS.ipynb
+++ b/notebooks/Example B.1 -- Level BFS.ipynb
@@ -20,9 +20,8 @@
     "import networkx as nx\n",
     "import matplotlib.pyplot as plt\n",
     "import grblas as gb\n",
-    "gb.init('suitesparse')\n",
     "from grblas import lib, ffi, Matrix, Vector, Scalar\n",
-    "from grblas.base import NULL, REPLACE\n",
+    "from grblas.base import NULL\n",
     "from grblas import dtypes\n",
     "from grblas import descriptor\n",
     "from grblas import UnaryOp, BinaryOp, Monoid, Semiring\n",
@@ -130,7 +129,7 @@
     "n = A.nrows\n",
     "v = Vector.new_from_type(dtypes.INT32, n)\n",
     "q = Vector.new_from_type(bool, n)\n",
-    "q.element[s] = True\n",
+    "q[s] << True\n",
     "succ = Scalar.new_from_type(bool)"
    ]
   },
@@ -144,11 +143,11 @@
     "while True:\n",
     "    d += 1\n",
     "    # For the frontier, assign the depth level\n",
-    "    v.assign[q] = d\n",
+    "    v[:](mask=q) << d\n",
     "    # Compute the next frontier, masking out anything already assigned\n",
-    "    q[~v, REPLACE] = q.vxm(A, Semiring.LOR_LAND)\n",
+    "    q(~v, replace=True) << q.vxm(A, Semiring.LOR_LAND)\n",
     "    # If next frontier is empty, we're done\n",
-    "    succ[:] = q.reduce(Monoid.LOR)\n",
+    "    succ << q.reduce(Monoid.LOR)\n",
     "    if not succ:\n",
     "        break\n",
     "v.show()"
@@ -170,7 +169,7 @@
     "# Only run this cell once -- it initializes things\n",
     "v.clear()\n",
     "q.clear()\n",
-    "q.element[s] = True\n",
+    "q[s] << True\n",
     "d = 0"
    ]
   },
@@ -182,7 +181,7 @@
    "source": [
     "d += 1\n",
     "# For the frontier, assign the depth level\n",
-    "v.assign[q] = d\n",
+    "v[:](mask=q) << d\n",
     "v.show()"
    ]
   },
@@ -193,7 +192,7 @@
    "outputs": [],
    "source": [
     "# Compute the next frontier, masking out anything already assigned\n",
-    "q[~v, REPLACE] = q.vxm(A, Semiring.LOR_LAND)\n",
+    "q(~v, replace=True) << q.vxm(A, Semiring.LOR_LAND)\n",
     "q.show()\n",
     "# These are the next layer of the BFS, prep'd for the next iteration"
    ]
@@ -204,7 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "succ[:] = q.reduce(Monoid.LOR)\n",
+    "succ << q.reduce(Monoid.LOR)\n",
     "print('Continue' if succ else 'Done')"
    ]
   },

--- a/notebooks/Example B.3 -- Parent BFS.ipynb
+++ b/notebooks/Example B.3 -- Parent BFS.ipynb
@@ -20,9 +20,8 @@
     "import networkx as nx\n",
     "import matplotlib.pyplot as plt\n",
     "import grblas as gb\n",
-    "gb.init('suitesparse')\n",
     "from grblas import lib, ffi, Matrix, Vector, Scalar\n",
-    "from grblas.base import NULL, REPLACE\n",
+    "from grblas.base import NULL\n",
     "from grblas import dtypes\n",
     "from grblas import descriptor\n",
     "from grblas import UnaryOp, BinaryOp, Monoid, Semiring\n",
@@ -144,9 +143,9 @@
     "index_ramp = Vector.new_from_type(dtypes.UINT64, N)\n",
     "index_ramp.rebuild_from_values(range(N), range(N))\n",
     "parents = Vector.new_from_type(dtypes.UINT64, N)\n",
-    "parents.element[s] = s\n",
+    "parents[s] << s\n",
     "wavefront = Vector.new_from_type(dtypes.UINT64, N)\n",
-    "wavefront.element[s] = 1"
+    "wavefront[s] << 1"
    ]
   },
   {
@@ -157,13 +156,13 @@
    "source": [
     "while wavefront.nvals > 0:\n",
     "    # convert all stored values in wavefront to their 0−based index\n",
-    "    wavefront[:] = index_ramp.ewise_mult(wavefront, BinaryOp.FIRST)\n",
+    "    wavefront << index_ramp.ewise_mult(wavefront, BinaryOp.FIRST)\n",
     "    # ”FIRST” because left−multiplying wavefront rows. Masking out the parent\n",
     "    # list ensures wavefront values do not overwrite parents already stored.\n",
-    "    wavefront[~parents, REPLACE] = wavefront.vxm(A, Semiring.MIN_FIRST)\n",
+    "    wavefront(~parents, replace=True) << wavefront.vxm(A, Semiring.MIN_FIRST)\n",
     "    # Don’t need to mask here since we did it in mxm. Merges new parents in\n",
     "    # current wave front with existing parents : parents += wavefront\n",
-    "    parents[BinaryOp.PLUS] = wavefront.apply(UnaryOp.IDENTITY)\n",
+    "    parents(BinaryOp.PLUS) << wavefront.apply(UnaryOp.IDENTITY)\n",
     "parents.show()"
    ]
   },
@@ -182,9 +181,9 @@
    "source": [
     "# Only run this cell once -- it initializes things\n",
     "parents.clear()\n",
-    "parents.element[s] = s\n",
+    "parents[s] << s\n",
     "wavefront.clear()\n",
-    "wavefront.element[s] = 1"
+    "wavefront[s] << 1"
    ]
   },
   {
@@ -203,7 +202,7 @@
    "outputs": [],
    "source": [
     "# convert all stored values in wavefront to their 0−based index\n",
-    "wavefront[:] = index_ramp.ewise_mult(wavefront, BinaryOp.FIRST)\n",
+    "wavefront << index_ramp.ewise_mult(wavefront, BinaryOp.FIRST)\n",
     "wavefront.show()"
    ]
   },
@@ -215,7 +214,7 @@
    "source": [
     "# ”FIRST” because left−multiplying wavefront rows. Masking out the parent\n",
     "# list ensures wavefront values do not overwrite parents already stored.\n",
-    "wavefront[~parents, REPLACE] = wavefront.vxm(A, Semiring.MIN_FIRST)\n",
+    "wavefront(~parents, replace=True) << wavefront.vxm(A, Semiring.MIN_FIRST)\n",
     "wavefront.show()"
    ]
   },
@@ -227,7 +226,7 @@
    "source": [
     "# Don’t need to mask here since we did it in mxm. Merges new parents in\n",
     "# current wave front with existing parents : parents += wavefront\n",
-    "parents[BinaryOp.PLUS] = wavefront.apply(UnaryOp.IDENTITY)\n",
+    "parents(BinaryOp.PLUS) << wavefront.apply(UnaryOp.IDENTITY)\n",
     "parents.show()"
    ]
   },

--- a/notebooks/Intro to GraphBLAS + SSSP example.ipynb
+++ b/notebooks/Intro to GraphBLAS + SSSP example.ipynb
@@ -11,8 +11,7 @@
     "import networkx as nx\n",
     "import matplotlib.pyplot as plt\n",
     "import grblas\n",
-    "grblas.init('suitesparse')\n",
-    "from grblas import Matrix, Vector\n",
+    "from grblas import Matrix, Vector, Scalar\n",
     "from grblas import descriptor\n",
     "from grblas import UnaryOp, BinaryOp, Monoid, Semiring\n",
     "from grblas import io as gio"
@@ -72,6 +71,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -84,8 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "v = Vector.new_from_type(m.dtype, m.nrows)\n",
-    "v.element[1] = 0"
+    "v = Vector.new_from_values([1], [0], dtype=m.dtype, size=m.nrows)"
    ]
   },
   {
@@ -114,7 +119,7 @@
    "source": [
     "# Create a vector and initialize a starting vertex (1) with a distance of zero\n",
     "v = Vector.new_from_type(m.dtype, m.nrows)\n",
-    "v.element[1] = 0\n",
+    "v[1] = 0\n",
     "v.show()"
    ]
   },
@@ -135,7 +140,7 @@
    "source": [
     "# v @ m will give us one step in a Breadth-first search\n",
     "w = Vector.new_from_existing(v)\n",
-    "w[:] = v.vxm(m, Semiring.MIN_PLUS)\n",
+    "w << v.vxm(m, Semiring.MIN_PLUS)\n",
     "w.show()"
    ]
   },
@@ -166,7 +171,7 @@
    "outputs": [],
    "source": [
     "w = Vector.new_from_existing(v)\n",
-    "w[BinaryOp.MIN] = v.vxm(m, Semiring.MIN_PLUS)\n",
+    "w(BinaryOp.MIN) << v.vxm(m, Semiring.MIN_PLUS)\n",
     "w.show()\n",
     "# Now we see that the zero distance for vertex 1 is preserved"
    ]
@@ -184,7 +189,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "w[BinaryOp.MIN] = w.vxm(m, Semiring.MIN_PLUS)\n",
+    "w(BinaryOp.MIN) << w.vxm(m, Semiring.MIN_PLUS)\n",
     "w.show()\n",
     "# We see that the path to vertex 4 is now shorter. That's `min` doing its thing.\n",
     "# Verify the other path distances from vertex 1 with at most two hops"
@@ -214,8 +219,8 @@
    "source": [
     "w = Vector.new_from_existing(v)\n",
     "while True:\n",
-    "    w_old = Vector.new_from_existing(w)\n",
-    "    w[BinaryOp.MIN] = w.vxm(m, Semiring.MIN_PLUS)\n",
+    "    w_old = w.dup()\n",
+    "    w(BinaryOp.MIN) << w.vxm(m, Semiring.MIN_PLUS)\n",
     "    if w == w_old:\n",
     "        break\n",
     "w.show()"
@@ -262,7 +267,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "v[:] = v.vxm(m_ident, Semiring.MIN_PLUS)\n",
+    "v << v.vxm(m_ident, Semiring.MIN_PLUS)\n",
     "v.show()\n",
     "# See how it preserved v exactly"
    ]
@@ -275,7 +280,7 @@
    "source": [
     "# Let's try again\n",
     "v.rebuild_from_values([0, 1, 4], [14, 0, 77])\n",
-    "v[:] = v.vxm(m_ident, Semiring.MIN_PLUS)\n",
+    "v << v.vxm(m_ident, Semiring.MIN_PLUS)\n",
     "v.show()"
    ]
   },
@@ -293,7 +298,7 @@
    "outputs": [],
    "source": [
     "for i in range(m.nrows):\n",
-    "    m.element[i, i] = 0\n",
+    "    m[i, i] = 0\n",
     "m.show()"
    ]
   },
@@ -305,7 +310,7 @@
    "source": [
     "# Reset v\n",
     "v.clear()\n",
-    "v.element[1] = 0\n",
+    "v[1] = 0\n",
     "v.show()"
    ]
   },
@@ -316,7 +321,7 @@
    "outputs": [],
    "source": [
     "# Take one step (notice no accumulator is specified)\n",
-    "v[:] = v.vxm(m, Semiring.MIN_PLUS)\n",
+    "v << v.vxm(m, Semiring.MIN_PLUS)\n",
     "v.show()"
    ]
   },
@@ -328,8 +333,8 @@
    "source": [
     "# Repeat until we're converged\n",
     "while True:\n",
-    "    w = Vector.new_from_existing(v)\n",
-    "    v[:] = v.vxm(m, Semiring.MIN_PLUS)\n",
+    "    w = v.dup()\n",
+    "    v << v.vxm(m, Semiring.MIN_PLUS)\n",
     "    if v == w:\n",
     "        break\n",
     "v.show()"

--- a/notebooks/Louvain.ipynb
+++ b/notebooks/Louvain.ipynb
@@ -6,12 +6,12 @@
    "source": [
     "### General note about spec v1.2\n",
     "\n",
-    "We really want `v[:] = v.apply(grblas.BinaryOp.TIMES, right=2)` (_coming in v1.3_)<br>\n",
-    "We can spell it like this: `v.assign[v, grblas.BinaryOp.TIMES] = 2`<br>\n",
+    "We really want `v << v.apply(grblas.BinaryOp.TIMES, right=2)` (_coming in v1.3_)<br>\n",
+    "We can spell it like this: `v[:](mask=v, accum=grblas.BinaryOp.TIMES) << 2`<br>\n",
     "But that requires using v as a mask and doesn't allow for the dtype to change.<br>\n",
     "For example, this is impossible in v1.2 but possible in v1.3:\n",
     "`w = grblas.Vector.new_from_type(grblas.dtypes.BOOL, v.size)`<br>\n",
-    "`w[:] = v.apply(grblas.BinaryOp.EQ, right=2.7)`"
+    "`w << v.apply(grblas.BinaryOp.EQ, right=2.7)`"
    ]
   },
   {
@@ -28,7 +28,6 @@
     "from collections import namedtuple\n",
     "from scipy.sparse import csr_matrix\n",
     "import grblas\n",
-    "grblas.init('suitesparse')\n",
     "from grblas import Matrix, Vector\n",
     "from grblas import descriptor\n",
     "from grblas import UnaryOp, BinaryOp, Monoid, Semiring\n",
@@ -71,7 +70,7 @@
     "        self.beyond_last_index = nn\n",
     "        self.beyond_last = grblas.Vector.new_from_values([self.beyond_last_index], [1], size=nc)\n",
     "        self.ki_all = grblas.Vector.new_from_type(grblas.dtypes.FP64, size=nn)\n",
-    "        self.ki_all[:] = adj.reduce_columns(grblas.Monoid.PLUS)\n",
+    "        self.ki_all << adj.reduce_columns(grblas.Monoid.PLUS)\n",
     "        self.sigma_total = grblas.Vector.new_from_type(grblas.dtypes.FP64, size=nc)\n",
     "        self.ki_in = grblas.Vector.new_from_type(grblas.dtypes.FP64, size=nc)\n",
     "        self.max_modularity_delta = grblas.Scalar.new_from_type(grblas.dtypes.FP64)\n",
@@ -96,16 +95,16 @@
     "        community = self.community\n",
     "        modularity = self.modularity\n",
     "            \n",
-    "        self.community_tmp[:] = comms.mxm(adj)\n",
-    "        community[:] = self.community_tmp.mxm(comms.T)\n",
-    "        self.diag_matrix[self.diag_mask] = community\n",
-    "        self.diag_vector[:] = self.diag_matrix.reduce_columns()  # Aij\n",
-    "        modularity[:] = community.reduce_columns(grblas.BinaryOp.PLUS)  # ki\n",
-    "        modularity[:] = modularity.ewise_mult(modularity, grblas.BinaryOp.TIMES)  # ki^2\n",
-    "        modularity.assign[modularity, grblas.BinaryOp.DIV] = self.total_links_doubled  # ki^2/2m\n",
-    "        modularity.assign[modularity, grblas.BinaryOp.TIMES] = -1  # -ki^2\n",
-    "        modularity[:] = self.diag_vector.ewise_add(modularity, grblas.BinaryOp.PLUS)  # Aij - ki^2/2m\n",
-    "        modularity.assign[modularity, grblas.BinaryOp.DIV] = self.total_links_doubled  # (Aij - ki^2/2m) / 2m\n",
+    "        self.community_tmp << comms.mxm(adj)\n",
+    "        community << self.community_tmp.mxm(comms.T)\n",
+    "        self.diag_matrix(self.diag_mask) << community\n",
+    "        self.diag_vector << self.diag_matrix.reduce_columns()  # Aij\n",
+    "        modularity << community.reduce_columns(grblas.BinaryOp.PLUS)  # ki\n",
+    "        modularity << modularity.ewise_mult(modularity, grblas.BinaryOp.TIMES)  # ki^2\n",
+    "        modularity[:](mask=modularity, accum=grblas.BinaryOp.DIV) << self.total_links_doubled  # ki^2/2m\n",
+    "        modularity[:](mask=modularity, accum=grblas.BinaryOp.TIMES) << -1  # -ki^2\n",
+    "        modularity << self.diag_vector.ewise_add(modularity, grblas.BinaryOp.PLUS)  # Aij - ki^2/2m\n",
+    "        modularity[:](mask=modularity, accum=grblas.BinaryOp.DIV) << self.total_links_doubled  # (Aij - ki^2/2m) / 2m\n",
     "        result = modularity.reduce(grblas.Monoid.PLUS).new()  # (1/2m)*sum(Aij - ki^2/2m)\n",
     "\n",
     "        return result\n",
@@ -120,46 +119,46 @@
     "        community = self.community\n",
     "        sigma_total = self.sigma_total\n",
     "        # Save current modularity score in current community\n",
-    "        self.stored_community[:] = comms.extract[:, node]\n",
-    "        current_community_index = next(self.stored_community.to_values()[0])\n",
+    "        self.stored_community << comms[:, node]\n",
+    "        current_community_index = self.stored_community.to_values()[0][0]\n",
     "        orig_modularity_score = self.compute_modularity(comms)\n",
     "\n",
     "        # Move node to its own community\n",
-    "        comms.assign[:, node] = self.beyond_last\n",
+    "        comms[:, node] << self.beyond_last\n",
     "        baseline_modularity_score = self.compute_modularity(comms)\n",
     "\n",
     "        # Compute modularity improvements for each neighbor\n",
     "        total_links_doubled = self.total_links_doubled.value\n",
-    "        ki = self.ki_all.element[node]\n",
-    "        self.community_tmp[:] = comms.mxm(adj)\n",
-    "        community[:] = self.community_tmp.mxm(comms.T)\n",
-    "        sigma_total[:] = community.reduce_columns(grblas.Monoid.PLUS)\n",
-    "        self.ki_in[~self.beyond_last, grblas.REPLACE] = self.beyond_last.vxm(community)\n",
+    "        ki = self.ki_all[node].value\n",
+    "        self.community_tmp << comms.mxm(adj)\n",
+    "        community << self.community_tmp.mxm(comms.T)\n",
+    "        sigma_total << community.reduce_columns(grblas.Monoid.PLUS)\n",
+    "        self.ki_in(~self.beyond_last, replace=True) << self.beyond_last.vxm(community)\n",
     "        # delta = 2*ki_in/total_links_doubled - 2*sigma_total*ki/total_links_doubled^2\n",
     "        delta = self.ki_in\n",
-    "        delta.assign[delta, grblas.BinaryOp.TIMES] = 2/total_links_doubled\n",
-    "        sigma_total.assign[sigma_total, grblas.BinaryOp.TIMES] = -2*ki/total_links_doubled**2\n",
-    "        delta[:] = delta.ewise_mult(sigma_total, grblas.BinaryOp.PLUS)\n",
+    "        delta[:](mask=delta, accum=grblas.BinaryOp.TIMES) << 2/total_links_doubled\n",
+    "        sigma_total[:](mask=sigma_total, accum=grblas.BinaryOp.TIMES) << -2*ki/total_links_doubled**2\n",
+    "        delta << delta.ewise_mult(sigma_total, grblas.BinaryOp.PLUS)\n",
     "\n",
     "        # Choose best neighbor\n",
     "        max_modularity_delta = self.max_modularity_delta\n",
-    "        max_modularity_delta[:] = delta.reduce(grblas.Monoid.MAX)\n",
+    "        max_modularity_delta << delta.reduce(grblas.Monoid.MAX)\n",
     "\n",
     "        # If modularity is improved, update comms and return True\n",
     "        if max_modularity_delta.value > orig_modularity_score.value - baseline_modularity_score.value:\n",
-    "            self.max_mask[:] = delta\n",
-    "            self.max_mask.assign[self.max_mask, grblas.BinaryOp.EQ] = max_modularity_delta\n",
-    "            delta[self.max_mask, grblas.REPLACE] = delta  # eliminate all but the max value(s)\n",
+    "            self.max_mask << delta\n",
+    "            self.max_mask[:](self.max_mask, grblas.BinaryOp.EQ) << max_modularity_delta\n",
+    "            delta(self.max_mask, replace=True) << delta  # eliminate all but the max value(s)\n",
     "            indexes, vals = delta.to_values()\n",
-    "            best_community_index = next(indexes)\n",
+    "            best_community_index = indexes[0]\n",
     "            # Guard against reassigning a node to its existing community\n",
     "            if best_community_index != current_community_index and best_community_index != self.beyond_last_index:\n",
-    "                self.stored_community[:] = comms.extract[:, best_community_index]\n",
-    "                comms.assign[:, node] = self.stored_community\n",
+    "                self.stored_community << comms[:, best_community_index]\n",
+    "                comms[:, node] << self.stored_community\n",
     "                return True\n",
     "\n",
     "        # If modularity isn't improved, reset and return False\n",
-    "        comms.assign[:, node] = self.stored_community\n",
+    "        comms[:, node] << self.stored_community\n",
     "        return False\n",
     "\n",
     "    def optimize_communities(self, max_iter=20):\n",
@@ -188,7 +187,7 @@
     "        rows, cols, vals = comms.to_values()\n",
     "        nonzero_rows = list(sorted(set(rows)))\n",
     "        compact_comms = grblas.Matrix.new_from_type(comms.dtype, nrows=len(nonzero_rows), ncols=self.nn)\n",
-    "        compact_comms[:] = comms.extract[nonzero_rows, :]\n",
+    "        compact_comms << comms[nonzero_rows, :]\n",
     "\n",
     "        return compact_comms"
    ]
@@ -224,12 +223,19 @@
     "        prev_adj = adj.adj\n",
     "        adj_tmp = grblas.Matrix.new_from_type(prev_adj.dtype, nrows=nc, ncols=prev_adj.nrows)\n",
     "        adj = grblas.Matrix.new_from_type(prev_adj.dtype, nrows=nc, ncols=nc)\n",
-    "        adj_tmp[:] = comms.mxm(prev_adj)\n",
-    "        adj[:] = adj_tmp.mxm(comms.T)\n",
+    "        adj_tmp << comms.mxm(prev_adj)\n",
+    "        adj << adj_tmp.mxm(comms.T)\n",
     "        adj = AdjMatrix(adj)\n",
     "        \n",
     "    return results"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -312,6 +318,15 @@
    "source": [
     "# This is the new adjacency matrix after collapsing communities into nodes\n",
     "l[1].adj.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "l[1].modscore"
    ]
   },
   {
@@ -402,7 +417,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "l[2].modscore"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -469,6 +486,13 @@
    "source": [
     "l[2].adj.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grblas" %}
-{% set version = "1.2.3" %}
+{% set version = "1.2.4" %}
 
 package:
   name: "{{ name|lower }}"
@@ -14,21 +14,21 @@ build:
 
 requirements:
   build:
-    - python >=3.5,<3.8
+    - python >=3.6
     - cffi
-    - ss_graphblas ==3.1.1
+    - graphblas ==3.1.1
     - pytest-runner
   
   host:
-    - python >=3.5,<3.8
+    - python >=3.6
     - cffi
-    - ss_graphblas ==3.1.1
+    - graphblas ==3.1.1
     - pytest-runner
 
   run:
-    - python >=3.5,<3.8
+    - python >=3.6
     - cffi
-    - ss_graphblas ==3.1.1
+    - graphblas ==3.1.1
     - numba
 
 about:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [aliases]
 test=pytest
+
+[flake8]
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='grblas',
-    version='1.2.3',
+    version='1.2.4',
     description='Python interface to GraphBLAS',
     author='Jim Kitchen',
     packages=['grblas', 'grblas/backends', 'grblas/backends/suitesparse'],

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,8 @@
-import pytest
-
 def pytest_addoption(parser):
     parser.addoption(
         "--backend", action="store", default="suitesparse", help="name of a backend in grblas.backends"
     )
+
 
 def pytest_configure(config):
     backend = config.getoption('--backend')

--- a/test/test_descriptor.py
+++ b/test/test_descriptor.py
@@ -1,16 +1,17 @@
-import pytest
 from grblas import descriptor, ffi
+
 
 def test_caching():
     """
     Test that building a descriptor is actually caching rather than building
     a new object for each call.
     """
-    tocr = descriptor.build(output_replace=True, mask_complement=True, 
+    tocr = descriptor.build(output_replace=True, mask_complement=True,
                             transpose_first=True, transpose_second=False)
-    tocr2 = descriptor.build(output_replace=True, mask_complement=True, 
+    tocr2 = descriptor.build(output_replace=True, mask_complement=True,
                              transpose_first=True, transpose_second=False)
     assert tocr is tocr2
+
 
 def test_null_desc():
     """

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -1,4 +1,3 @@
-import pytest
 from grblas import dtypes, lib
 
 all_dtypes = (
@@ -15,6 +14,7 @@ all_dtypes = (
     dtypes.FP64,
 )
 
+
 def test_names():
     assert dtypes.BOOL.name == 'BOOL'
     assert dtypes.INT8.name == 'INT8'
@@ -27,6 +27,7 @@ def test_names():
     assert dtypes.UINT64.name == 'UINT64'
     assert dtypes.FP32.name == 'FP32'
     assert dtypes.FP64.name == 'FP64'
+
 
 def test_ctype():
     assert dtypes.BOOL.c_type == '_Bool'
@@ -41,6 +42,7 @@ def test_ctype():
     assert dtypes.FP32.c_type == 'float'
     assert dtypes.FP64.c_type == 'double'
 
+
 def test_gbtype():
     assert dtypes.BOOL.gb_type == lib.GrB_BOOL
     assert dtypes.INT8.gb_type == lib.GrB_INT8
@@ -54,22 +56,27 @@ def test_gbtype():
     assert dtypes.FP32.gb_type == lib.GrB_FP32
     assert dtypes.FP64.gb_type == lib.GrB_FP64
 
+
 def test_lookup_by_name():
     for dt in all_dtypes:
         assert dtypes.lookup(dt.name) is dt
+
 
 def test_lookup_by_ctype():
     for dt in all_dtypes:
         assert dtypes.lookup(dt.c_type) is dt
 
+
 def test_lookup_by_gbtype():
     for dt in all_dtypes:
         assert dtypes.lookup(dt.gb_type) is dt
+
 
 def test_lookup_by_dtype():
     assert dtypes.lookup(bool) == dtypes.BOOL
     assert dtypes.lookup(int) == dtypes.INT64
     assert dtypes.lookup(float) == dtypes.FP64
+
 
 def test_unify_dtypes():
     assert dtypes.unify(dtypes.BOOL, dtypes.BOOL) == dtypes.BOOL

--- a/test/test_op.py
+++ b/test/test_op.py
@@ -4,41 +4,51 @@ from grblas import UnaryOp, BinaryOp, Monoid, Semiring
 from grblas import dtypes, ops
 from grblas import Vector, Matrix
 
+
 def test_unaryop():
     assert UnaryOp.AINV['INT32'] == lib.GrB_AINV_INT32
     assert UnaryOp.AINV[dtypes.UINT16] == lib.GrB_AINV_UINT16
+
 
 def test_binaryop():
     assert BinaryOp.PLUS['INT32'] == lib.GrB_PLUS_INT32
     assert BinaryOp.PLUS[dtypes.UINT16] == lib.GrB_PLUS_UINT16
 
+
 def test_monoid():
     assert Monoid.MAX['INT32'] == lib.GxB_MAX_INT32_MONOID
     assert Monoid.MAX[dtypes.UINT16] == lib.GxB_MAX_UINT16_MONOID
+
 
 def test_semiring():
     assert Semiring.MIN_PLUS['INT32'] == lib.GxB_MIN_PLUS_INT32
     assert Semiring.MIN_PLUS[dtypes.UINT16] == lib.GxB_MIN_PLUS_UINT16
 
+
 def test_find_opclass_unaryop():
     assert ops.find_opclass(UnaryOp.MINV) == 'UnaryOp'
     assert ops.find_opclass(lib.GrB_MINV_INT64) == 'UnaryOp'
+
 
 def test_find_opclass_binaryop():
     assert ops.find_opclass(BinaryOp.TIMES) == 'BinaryOp'
     assert ops.find_opclass(lib.GrB_TIMES_INT64) == 'BinaryOp'
 
+
 def test_find_opclass_monoid():
     assert ops.find_opclass(Monoid.MAX) == 'Monoid'
     assert ops.find_opclass(lib.GxB_MAX_INT64_MONOID) == 'Monoid'
+
 
 def test_find_opclass_semiring():
     assert ops.find_opclass(Semiring.PLUS_PLUS) == 'Semiring'
     assert ops.find_opclass(lib.GxB_PLUS_PLUS_INT64) == 'Semiring'
 
+
 def test_find_opclass_invalid():
     assert ops.find_opclass('foobar') == ops.UNKNOWN_OPCLASS
     assert ops.find_opclass(lib.GrB_INP0) == ops.UNKNOWN_OPCLASS
+
 
 def test_unaryop_udf():
     def plus_one(x):
@@ -48,10 +58,11 @@ def test_unaryop_udf():
     assert UnaryOp.plus_one.types == {'INT8', 'INT16', 'INT32', 'INT64',
                                       'UINT8', 'UINT16', 'UINT32', 'UINT64',
                                       'FP32', 'FP64'}
-    v = Vector.new_from_values([0,1,3], [1,2,-4], dtype=dtypes.INT32)
+    v = Vector.new_from_values([0, 1, 3], [1, 2, -4], dtype=dtypes.INT32)
     v << v.apply(UnaryOp.plus_one)
-    result = Vector.new_from_values([0,1,3], [2,3,-3], dtype=dtypes.INT32)
+    result = Vector.new_from_values([0, 1, 3], [2, 3, -3], dtype=dtypes.INT32)
     assert v == result
+
 
 def test_unaryop_udf_bool_result():
     pytest.xfail('not sure why numba has trouble compiling this')
@@ -67,6 +78,7 @@ def test_unaryop_udf_bool_result():
     # result = Vector.new_from_values([0,1,3], [True,True,False], dtype=dtypes.BOOL)
     # assert v == result
 
+
 def test_binaryop_udf():
     def times_minus_sum(x, y):
         return x * y - (x + y)
@@ -75,11 +87,12 @@ def test_binaryop_udf():
     assert BinaryOp.bin_test_func.types == {'INT8', 'INT16', 'INT32', 'INT64',
                                             'UINT8', 'UINT16', 'UINT32', 'UINT64',
                                             'FP32', 'FP64'}
-    v1 = Vector.new_from_values([0,1,3], [1,2,-4], dtype=dtypes.INT32)
-    v2 = Vector.new_from_values([0,2,3], [2,3,7], dtype=dtypes.INT32)
+    v1 = Vector.new_from_values([0, 1, 3], [1, 2, -4], dtype=dtypes.INT32)
+    v2 = Vector.new_from_values([0, 2, 3], [2, 3, 7], dtype=dtypes.INT32)
     w = v1.ewise_add(v2, BinaryOp.bin_test_func).new()
-    result = Vector.new_from_values([0,1,2,3], [-1,2,3,-31], dtype=dtypes.INT32)
+    result = Vector.new_from_values([0, 1, 2, 3], [-1, 2, 3, -31], dtype=dtypes.INT32)
     assert w == result
+
 
 def test_monoid_udf():
     def plus_plus_one(x, y):
@@ -90,19 +103,22 @@ def test_monoid_udf():
     assert Monoid.plus_plus_one.types == {'INT8', 'INT16', 'INT32', 'INT64',
                                           'UINT8', 'UINT16', 'UINT32', 'UINT64',
                                           'FP32', 'FP64'}
-    v1 = Vector.new_from_values([0,1,3], [1,2,-4], dtype=dtypes.INT32)
-    v2 = Vector.new_from_values([0,2,3], [2,3,7], dtype=dtypes.INT32)
+    v1 = Vector.new_from_values([0, 1, 3], [1, 2, -4], dtype=dtypes.INT32)
+    v2 = Vector.new_from_values([0, 2, 3], [2, 3, 7], dtype=dtypes.INT32)
     w = v1.ewise_add(v2, Monoid.plus_plus_one).new()
-    result = Vector.new_from_values([0,1,2,3], [4,2,3,4], dtype=dtypes.INT32)
+    result = Vector.new_from_values([0, 1, 2, 3], [4, 2, 3, 4], dtype=dtypes.INT32)
     assert w == result
+
 
 def test_semiring_udf():
     def plus_plus_two(x, y):
         return x + y + 2
     BinaryOp.register_new('plus_plus_two', plus_plus_two)
     Semiring.register_new('extra_twos', Monoid.PLUS, BinaryOp.plus_plus_two)
-    v = Vector.new_from_values([0,1,3], [1,2,-4], dtype=dtypes.INT32)
-    A = Matrix.new_from_values([0,0,0,0,3,3,3,3], [0,1,2,3,0,1,2,3], [2,3,4,5,6,7,8,9], dtype=dtypes.INT32)
+    v = Vector.new_from_values([0, 1, 3], [1, 2, -4], dtype=dtypes.INT32)
+    A = Matrix.new_from_values([0, 0, 0, 0, 3, 3, 3, 3],
+                               [0, 1, 2, 3, 0, 1, 2, 3],
+                               [2, 3, 4, 5, 6, 7, 8, 9], dtype=dtypes.INT32)
     w = v.vxm(A, Semiring.extra_twos).new()
-    result = Vector.new_from_values([0,1,2,3], [9,11,13,15], dtype=dtypes.INT32)
+    result = Vector.new_from_values([0, 1, 2, 3], [9, 11, 13, 15], dtype=dtypes.INT32)
     assert w == result

--- a/test/test_op.py
+++ b/test/test_op.py
@@ -49,7 +49,7 @@ def test_unaryop_udf():
                                       'UINT8', 'UINT16', 'UINT32', 'UINT64',
                                       'FP32', 'FP64'}
     v = Vector.new_from_values([0,1,3], [1,2,-4], dtype=dtypes.INT32)
-    v[:] = v.apply(UnaryOp.plus_one)
+    v << v.apply(UnaryOp.plus_one)
     result = Vector.new_from_values([0,1,3], [2,3,-3], dtype=dtypes.INT32)
     assert v == result
 

--- a/test/test_resolving.py
+++ b/test/test_resolving.py
@@ -1,33 +1,35 @@
 import pytest
-from grblas import lib, ffi
-from grblas import Matrix, Vector, Scalar
-from grblas import UnaryOp, BinaryOp, Monoid, Semiring
-from grblas import dtypes, descriptor
+from grblas import Matrix, Vector
+from grblas import UnaryOp, BinaryOp
+from grblas import dtypes
 from grblas.base import Updater
-from grblas.exceptions import IndexOutOfBound, DimensionMismatch
+
 
 def test_new_from_values_dtype_resolving():
-    u = Vector.new_from_values([0,1,2], [1,2,3], dtype=dtypes.INT32)
+    u = Vector.new_from_values([0, 1, 2], [1, 2, 3], dtype=dtypes.INT32)
     assert u.dtype == 'INT32'
-    u = Vector.new_from_values([0,1,2], [1,2,3], dtype='INT32')
+    u = Vector.new_from_values([0, 1, 2], [1, 2, 3], dtype='INT32')
     assert u.dtype == dtypes.INT32
-    M = Matrix.new_from_values([0,1,2], [2,0,1], [0,2,3], dtype=dtypes.UINT8)
+    M = Matrix.new_from_values([0, 1, 2], [2, 0, 1], [0, 2, 3], dtype=dtypes.UINT8)
     assert M.dtype == 'UINT8'
-    M = Matrix.new_from_values([0,1,2], [2,0,1], [0,2,3], dtype=float)
+    M = Matrix.new_from_values([0, 1, 2], [2, 0, 1], [0, 2, 3], dtype=float)
     assert M.dtype == dtypes.FP64
+
 
 def test_new_from_values_invalid_dtype():
     with pytest.raises(OverflowError):
-        Matrix.new_from_values([0,1,2], [2,0,1], [0,2,3], dtype=dtypes.BOOL)
+        Matrix.new_from_values([0, 1, 2], [2, 0, 1], [0, 2, 3], dtype=dtypes.BOOL)
+
 
 def test_resolve_ops_using_output_dtype():
-    # C[:] = A.ewise_mult(B, BinaryOp.PLUS) <-- PLUS should use same dtype as C, not A or B
+    # C << A.ewise_mult(B, BinaryOp.PLUS) <-- PLUS should use same dtype as C, not A or B
     u = Vector.new_from_values([0, 1, 3], [1, 2, 3], dtype=dtypes.INT64)
     v = Vector.new_from_values([0, 1, 3], [0.1, 0.1, 0.1], dtype='FP64')
     w = Vector.new_from_type('FP32', u.size)
     w << u.ewise_mult(v, BinaryOp.PLUS)
     # Element[0] should be 1.1; check approximate equality
     assert abs(w[0].value - 1.1) < 1e-6
+
 
 def test_order_of_updater_params_does_not_matter():
     u = Vector.new_from_values([0, 1, 3], [1, 2, 3])
@@ -55,12 +57,14 @@ def test_order_of_updater_params_does_not_matter():
     v(replace=True, mask=mask, accum=accum) << u.ewise_mult(u, BinaryOp.TIMES)
     assert v == result
 
+
 def test_already_resolved_ops_allowed_in_updater():
-    # C[BinaryOp.PLUS['FP64']] = ...
+    # C(BinaryOp.PLUS['FP64']) << ...
     u = Vector.new_from_values([0, 1, 3], [1, 2, 3])
     u(BinaryOp.PLUS['INT64']) << u.ewise_mult(u, BinaryOp.TIMES['INT64'])
     result = Vector.new_from_values([0, 1, 3], [2, 6, 12])
     assert u == result
+
 
 def test_updater_returns_updater():
     u = Vector.new_from_values([0, 1, 3], [1, 2, 3])

--- a/test/test_scalar.py
+++ b/test/test_scalar.py
@@ -12,15 +12,22 @@ def s():
 def test_new_from_type():
     s = Scalar.new_from_type(dtypes.INT8)
     assert s.dtype == 'INT8'
+    assert s.value is None
+    s.empty = False
     assert s.value == 0  # must hold a value; initialized to 0
     s2 = Scalar.new_from_type(bool)
     assert s2.dtype == 'BOOL'
+    assert s2.value is None
+    s2.empty = False
     assert s2.value == False  # must hold a value; initialized to False
 
 def test_new_from_existing(s):
     s2 = Scalar.new_from_existing(s)
     assert s2.dtype == s.dtype
     assert s2.value == s.value
+    s3 = s.dup()
+    assert s3.dtype == s.dtype
+    assert s3.value == s.value
 
 def test_new_from_value():
     s = Scalar.new_from_value(False)
@@ -32,12 +39,16 @@ def test_new_from_value():
 
 def test_clear(s):
     assert s.value == 5
+    assert not s.empty
     s.clear()
-    assert s.value == 0  # must hold a value; reset to 0
+    assert s.value is None
+    assert s.empty
     s2 = Scalar.new_from_value(True)
     assert s2.value == True
+    assert not s2.empty
     s2.clear()
-    assert s2.value == False  # must hold a value; reset to False
+    assert s2.value is None
+    assert s2.empty
 
 def test_equal(s):
     assert s.value == 5

--- a/test/test_scalar.py
+++ b/test/test_scalar.py
@@ -1,8 +1,7 @@
 import pytest
-from grblas import lib, ffi
 from grblas import Scalar
-from grblas import UnaryOp, BinaryOp, Monoid, Semiring
-from grblas import dtypes, descriptor
+from grblas import dtypes
+
 
 @pytest.fixture
 def s():
@@ -13,13 +12,14 @@ def test_new_from_type():
     s = Scalar.new_from_type(dtypes.INT8)
     assert s.dtype == 'INT8'
     assert s.value is None
-    s.empty = False
+    s.is_empty = False
     assert s.value == 0  # must hold a value; initialized to 0
     s2 = Scalar.new_from_type(bool)
     assert s2.dtype == 'BOOL'
     assert s2.value is None
-    s2.empty = False
-    assert s2.value == False  # must hold a value; initialized to False
+    s2.is_empty = False
+    assert s2.value is False  # must hold a value; initialized to False
+
 
 def test_new_from_existing(s):
     s2 = Scalar.new_from_existing(s)
@@ -29,31 +29,35 @@ def test_new_from_existing(s):
     assert s3.dtype == s.dtype
     assert s3.value == s.value
 
+
 def test_new_from_value():
     s = Scalar.new_from_value(False)
     assert s.dtype == bool
-    assert s.value == False
+    assert s.value is False
     s2 = Scalar.new_from_value(-1.1)
     assert s2.dtype == 'FP64'
     assert s2.value == -1.1
 
+
 def test_clear(s):
     assert s.value == 5
-    assert not s.empty
+    assert not s.is_empty
     s.clear()
     assert s.value is None
-    assert s.empty
+    assert s.is_empty
     s2 = Scalar.new_from_value(True)
-    assert s2.value == True
-    assert not s2.empty
+    assert s2.value is True
+    assert not s2.is_empty
     s2.clear()
     assert s2.value is None
-    assert s2.empty
+    assert s2.is_empty
+
 
 def test_equal(s):
     assert s.value == 5
     assert s == 5
     assert s != 27
+
 
 def test_truthy(s):
     assert s, 's did not register as truthy'
@@ -64,8 +68,10 @@ def test_truthy(s):
     with pytest.raises(AssertionError):
         assert not s2
 
+
 def test_get_value(s):
     assert s.value == 5
+
 
 def test_set_value(s):
     assert s.value == 5

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -1,24 +1,25 @@
 import pytest
-from grblas import lib, ffi
 from grblas import Matrix, Vector, Scalar
 from grblas import UnaryOp, BinaryOp, Monoid, Semiring
-from grblas import dtypes, descriptor
+from grblas import dtypes
 from grblas.exceptions import IndexOutOfBound
+
 
 @pytest.fixture
 def A():
     data = [
-        [3,0,3,5,6,0,6,1,6,2,4,1],
-        [0,1,2,2,2,3,3,4,4,5,5,6],
-        [3,2,3,1,5,3,7,8,3,1,7,4]
+        [3, 0, 3, 5, 6, 0, 6, 1, 6, 2, 4, 1],
+        [0, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 6],
+        [3, 2, 3, 1, 5, 3, 7, 8, 3, 1, 7, 4]
     ]
     return Matrix.new_from_values(*data)
+
 
 @pytest.fixture
 def v():
     data = [
-        [1,3,4,6],
-        [1,1,2,0]
+        [1, 3, 4, 6],
+        [1, 1, 2, 0]
     ]
     return Vector.new_from_values(*data)
 
@@ -29,6 +30,7 @@ def test_new_from_type():
     assert u.nvals == 0
     assert u.size == 17
 
+
 def test_new_from_existing(v):
     u = Vector.new_from_existing(v)
     assert u is not v
@@ -38,6 +40,7 @@ def test_new_from_existing(v):
     # Ensure they are not the same backend object
     v[0] = 1000
     assert u[0].value != 1000
+
 
 def test_new_from_values():
     u = Vector.new_from_values([0, 1, 3], [True, False, True])
@@ -57,19 +60,24 @@ def test_new_from_values():
         # Duplicate indices requires a dup_op
         Vector.new_from_values([0, 1, 1], [True, True, True])
 
+
 def test_clear(v):
     v.clear()
     assert v.nvals == 0
     assert v.size == 7
 
+
 def test_resize(v):
     pytest.xfail('Not implemented in GraphBLAS 1.2')
+
 
 def test_size(v):
     assert v.size == 7
 
+
 def test_nvals(v):
     assert v.nvals == 4
+
 
 def test_rebuild(v):
     assert v.nvals == 4
@@ -78,14 +86,17 @@ def test_rebuild(v):
     with pytest.raises(IndexOutOfBound):
         v.rebuild_from_values([0, 11], [1, 1])
 
+
 def test_extract_values(v):
     idx, vals = v.to_values()
     assert idx == (1, 3, 4, 6)
     assert vals == (1, 1, 2, 0)
 
+
 def test_extract_element(v):
     assert v[1].value == 1
     assert v[6].new() == 0
+
 
 def test_set_element(v):
     assert v[0].value is None
@@ -95,18 +106,22 @@ def test_set_element(v):
     assert v[0].value == 12
     assert v[1].new() == 9
 
+
 def test_remove_element(v):
     pytest.xfail('Not implemented in GraphBLAS 1.2')
 
+
 def test_vxm(v, A):
     w = v.vxm(A, Semiring.PLUS_TIMES).new()
-    result = Vector.new_from_values([0,2,3,4,5,6], [3,3,0,8,14,4])
+    result = Vector.new_from_values([0, 2, 3, 4, 5, 6], [3, 3, 0, 8, 14, 4])
     assert w == result
+
 
 def test_vxm_transpose(v, A):
     w = v.vxm(A.T, Semiring.PLUS_TIMES).new()
-    result = Vector.new_from_values([0,1,6], [5,16,13])
+    result = Vector.new_from_values([0, 1, 6], [5, 16, 13])
     assert w == result
+
 
 def test_vxm_nonsquare(v):
     A = Matrix.new_from_values([0, 3], [0, 1], [10, 20], nrows=7, ncols=2)
@@ -117,36 +132,39 @@ def test_vxm_nonsquare(v):
     w1 = v.vxm(A, Semiring.MIN_PLUS).new()
     assert w1 == u
     # Test the transpose case
-    v2 = Vector.new_from_values([0,1], [1,2])
+    v2 = Vector.new_from_values([0, 1], [1, 2])
     w2 = v2.vxm(A.T, Semiring.MIN_PLUS).new()
     assert w2.size == 7
+
 
 def test_vxm_mask(v, A):
     mask = Vector.new_from_values([0, 3, 4], [True, True, True], size=7)
     u = Vector.new_from_existing(v)
     u(mask) << v.vxm(A, Semiring.PLUS_TIMES)
-    result = Vector.new_from_values([0,1,3,4,6], [3,1,0,8,0], size=7)
+    result = Vector.new_from_values([0, 1, 3, 4, 6], [3, 1, 0, 8, 0], size=7)
     assert u == result
     u = Vector.new_from_existing(v)
     u(~mask) << v.vxm(A, Semiring.PLUS_TIMES)
-    result2 = Vector.new_from_values([2,3,4,5,6], [3,1,2,14,4], size=7)
+    result2 = Vector.new_from_values([2, 3, 4, 5, 6], [3, 1, 2, 14, 4], size=7)
     assert u == result2
     u = Vector.new_from_existing(v)
     u(replace=True, mask=mask) << v.vxm(A, Semiring.PLUS_TIMES)
-    result3 = Vector.new_from_values([0,3,4], [3,0,8], size=7)
+    result3 = Vector.new_from_values([0, 3, 4], [3, 0, 8], size=7)
     assert u == result3
     w = v.vxm(A, Semiring.PLUS_TIMES).new(mask=mask)
     assert w == result3
 
+
 def test_vxm_accum(v, A):
     v(BinaryOp.PLUS) << v.vxm(A, Semiring.PLUS_TIMES)
-    result = Vector.new_from_values([0,1,2,3,4,5,6], [3,1,3,1,10,14,4], size=7)
+    result = Vector.new_from_values([0, 1, 2, 3, 4, 5, 6], [3, 1, 3, 1, 10, 14, 4], size=7)
     assert v == result
+
 
 def test_ewise_mult(v):
     # Binary, Monoid, and Semiring
-    v2 = Vector.new_from_values([0,3,5,6], [2,3,2,1])
-    result = Vector.new_from_values([3,6], [3,0])
+    v2 = Vector.new_from_values([0, 3, 5, 6], [2, 3, 2, 1])
+    result = Vector.new_from_values([3, 6], [3, 0])
     w = v.ewise_mult(v2, BinaryOp.TIMES).new()
     assert w == result
     w << v.ewise_mult(v2, Monoid.TIMES)
@@ -154,19 +172,21 @@ def test_ewise_mult(v):
     w.update(v.ewise_mult(v2, Semiring.PLUS_TIMES))
     assert w == result
 
+
 def test_ewise_mult_change_dtype(v):
     # We want to divide by 2, converting ints to floats
-    v2 = Vector.new_from_values([1,3,4,6], [2,2,2,2])
+    v2 = Vector.new_from_values([1, 3, 4, 6], [2, 2, 2, 2])
     assert v.dtype == dtypes.INT64
     assert v2.dtype == dtypes.INT64
-    result = Vector.new_from_values([1,3,4,6], [0.5,0.5,1.0,0], dtype=dtypes.FP64)
+    result = Vector.new_from_values([1, 3, 4, 6], [0.5, 0.5, 1.0, 0], dtype=dtypes.FP64)
     w = v.ewise_mult(v2, BinaryOp.DIV).new(dtype=dtypes.FP64)
     assert w == result
 
+
 def test_ewise_add(v):
     # Binary, Monoid, and Semiring
-    v2 = Vector.new_from_values([0,3,5,6], [2,3,2,1])
-    result = Vector.new_from_values([0,1,3,4,5,6], [2,1,3,2,2,1])
+    v2 = Vector.new_from_values([0, 3, 5, 6], [2, 3, 2, 1])
+    result = Vector.new_from_values([0, 1, 3, 4, 5, 6], [2, 1, 3, 2, 2, 1])
     w = v.ewise_add(v2, BinaryOp.MAX).new()
     assert w == result
     w.update(v.ewise_add(v2, Monoid.MAX))
@@ -174,47 +194,53 @@ def test_ewise_add(v):
     w << v.ewise_add(v2, Semiring.MAX_TIMES)
     assert w == result
 
+
 def test_extract(v):
     w = Vector.new_from_type(v.dtype, 3)
-    result = Vector.new_from_values([0,1], [1,1], size=3)
-    w << v[[1,3,5]]
+    result = Vector.new_from_values([0, 1], [1, 1], size=3)
+    w << v[[1, 3, 5]]
     assert w == result
     w() << v[1::2]
     assert w == result
     w2 = v[1::2].new()
     assert w2 == w
 
+
 def test_assign(v):
-    u = Vector.new_from_values([0,2], [9, 8])
-    result = Vector.new_from_values([0,1,3,4,6], [9,1,1,8,0])
+    u = Vector.new_from_values([0, 2], [9, 8])
+    result = Vector.new_from_values([0, 1, 3, 4, 6], [9, 1, 1, 8, 0])
     w = Vector.new_from_existing(v)
-    w[[0,2,4]] = u
+    w[[0, 2, 4]] = u
     assert w == result
     w = Vector.new_from_existing(v)
     w[:5:2] << u
     assert w == result
 
+
 def test_assign_scalar(v):
-    result = Vector.new_from_values([1,3,4,5,6], [9,9,2,9,0])
+    result = Vector.new_from_values([1, 3, 4, 5, 6], [9, 9, 2, 9, 0])
     w = Vector.new_from_existing(v)
-    w[[1,3,5]] = 9
+    w[[1, 3, 5]] = 9
     assert w == result
     w = Vector.new_from_existing(v)
     w[1::2] = 9
     assert w == result
-    w = Vector.new_from_values([0,1,2], [1,1,1])
+    w = Vector.new_from_values([0, 1, 2], [1, 1, 1])
     s = Scalar.new_from_value(9)
     w[:] = s
-    assert w == Vector.new_from_values([0,1,2], [9,9,9])
+    assert w == Vector.new_from_values([0, 1, 2], [9, 9, 9])
+
 
 def test_apply(v):
-    result = Vector.new_from_values([1,3,4,6], [-1,-1,-2,0])
+    result = Vector.new_from_values([1, 3, 4, 6], [-1, -1, -2, 0])
     w = v.apply(UnaryOp.AINV).new()
     assert w == result
+
 
 def test_apply_binary(v):
     # Test bind-first and bind-second
     pytest.xfail('Not implemented in GraphBLAS 1.2')
+
 
 def test_reduce(v):
     s = v.reduce(Monoid.PLUS).new()
@@ -223,11 +249,13 @@ def test_reduce(v):
     s(accum=BinaryOp.TIMES) << v.reduce(Monoid.PLUS)
     assert s == 16
 
+
 def test_simple_assignment(v):
     # w[:] = v
     w = Vector.new_from_type(v.dtype, v.size)
     w << v
     assert w == v
+
 
 def test_equal(v):
     assert v == v
@@ -235,13 +263,14 @@ def test_equal(v):
     assert u != v
     u2 = Vector.new_from_values([1], [1], size=7)
     assert u2 != v
-    u3 = Vector.new_from_values([1,3,4,6], [1.,1.,2.,0.])
+    u3 = Vector.new_from_values([1, 3, 4, 6], [1., 1., 2., 0.])
     assert u3 != v, 'different datatypes are not equal'
+
 
 def test_binary_op(v):
     v2 = Vector.new_from_existing(v)
     v2[1] = 0
     w = v.ewise_mult(v2, BinaryOp.GT).new()
-    result = Vector.new_from_values([1,3,4,6], [True, False, False, False])
+    result = Vector.new_from_values([1, 3, 4, 6], [True, False, False, False])
     assert w.dtype == 'BOOL'
     assert w == result

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -3,7 +3,6 @@ from grblas import lib, ffi
 from grblas import Matrix, Vector, Scalar
 from grblas import UnaryOp, BinaryOp, Monoid, Semiring
 from grblas import dtypes, descriptor
-from grblas import REPLACE
 from grblas.exceptions import IndexOutOfBound
 
 @pytest.fixture
@@ -37,8 +36,8 @@ def test_new_from_existing(v):
     assert u.nvals == v.nvals
     assert u.size == v.size
     # Ensure they are not the same backend object
-    v.element[0] = 1000
-    assert u.element[0] != 1000
+    v[0] = 1000
+    assert u[0].value != 1000
 
 def test_new_from_values():
     u = Vector.new_from_values([0, 1, 3], [True, False, True])
@@ -53,7 +52,7 @@ def test_new_from_values():
     assert u3.size == 10
     assert u3.nvals == 2  # duplicates were combined
     assert u3.dtype == int
-    assert u3.element[1] == 6  # 2*3
+    assert u3[1].value == 6  # 2*3
     with pytest.raises(ValueError):
         # Duplicate indices requires a dup_op
         Vector.new_from_values([0, 1, 1], [True, True, True])
@@ -81,20 +80,20 @@ def test_rebuild(v):
 
 def test_extract_values(v):
     idx, vals = v.to_values()
-    assert tuple(idx) == (1, 3, 4, 6)
-    assert tuple(vals) == (1, 1, 2, 0)
+    assert idx == (1, 3, 4, 6)
+    assert vals == (1, 1, 2, 0)
 
 def test_extract_element(v):
-    assert v.element[1] == 1
-    assert v.element[6] == 0
+    assert v[1].value == 1
+    assert v[6].new() == 0
 
 def test_set_element(v):
-    assert v.element[0] is None
-    assert v.element[1] == 1
-    v.element[0] = 12
-    v.element[1] = 9
-    assert v.element[0] == 12
-    assert v.element[1] == 9
+    assert v[0].value is None
+    assert v[1].value == 1
+    v[0] = 12
+    v[1] << 9
+    assert v[0].value == 12
+    assert v[1].new() == 9
 
 def test_remove_element(v):
     pytest.xfail('Not implemented in GraphBLAS 1.2')
@@ -112,7 +111,7 @@ def test_vxm_transpose(v, A):
 def test_vxm_nonsquare(v):
     A = Matrix.new_from_values([0, 3], [0, 1], [10, 20], nrows=7, ncols=2)
     u = Vector.new_from_type(v.dtype, size=2)
-    u[:] = v.vxm(A, Semiring.MIN_PLUS)
+    u().update(v.vxm(A, Semiring.MIN_PLUS))
     result = Vector.new_from_values([1], [21])
     assert u == result
     w1 = v.vxm(A, Semiring.MIN_PLUS).new()
@@ -125,22 +124,22 @@ def test_vxm_nonsquare(v):
 def test_vxm_mask(v, A):
     mask = Vector.new_from_values([0, 3, 4], [True, True, True], size=7)
     u = Vector.new_from_existing(v)
-    u[mask] = v.vxm(A, Semiring.PLUS_TIMES)
+    u(mask) << v.vxm(A, Semiring.PLUS_TIMES)
     result = Vector.new_from_values([0,1,3,4,6], [3,1,0,8,0], size=7)
     assert u == result
     u = Vector.new_from_existing(v)
-    u[~mask] = v.vxm(A, Semiring.PLUS_TIMES)
+    u(~mask) << v.vxm(A, Semiring.PLUS_TIMES)
     result2 = Vector.new_from_values([2,3,4,5,6], [3,1,2,14,4], size=7)
     assert u == result2
     u = Vector.new_from_existing(v)
-    u[mask, REPLACE] = v.vxm(A, Semiring.PLUS_TIMES)
+    u(replace=True, mask=mask) << v.vxm(A, Semiring.PLUS_TIMES)
     result3 = Vector.new_from_values([0,3,4], [3,0,8], size=7)
     assert u == result3
     w = v.vxm(A, Semiring.PLUS_TIMES).new(mask=mask)
     assert w == result3
 
 def test_vxm_accum(v, A):
-    v[BinaryOp.PLUS] = v.vxm(A, Semiring.PLUS_TIMES)
+    v(BinaryOp.PLUS) << v.vxm(A, Semiring.PLUS_TIMES)
     result = Vector.new_from_values([0,1,2,3,4,5,6], [3,1,3,1,10,14,4], size=7)
     assert v == result
 
@@ -150,9 +149,9 @@ def test_ewise_mult(v):
     result = Vector.new_from_values([3,6], [3,0])
     w = v.ewise_mult(v2, BinaryOp.TIMES).new()
     assert w == result
-    w[:] = v.ewise_mult(v2, Monoid.TIMES)
+    w << v.ewise_mult(v2, Monoid.TIMES)
     assert w == result
-    w[:] = v.ewise_mult(v2, Semiring.PLUS_TIMES)
+    w.update(v.ewise_mult(v2, Semiring.PLUS_TIMES))
     assert w == result
 
 def test_ewise_mult_change_dtype(v):
@@ -170,42 +169,42 @@ def test_ewise_add(v):
     result = Vector.new_from_values([0,1,3,4,5,6], [2,1,3,2,2,1])
     w = v.ewise_add(v2, BinaryOp.MAX).new()
     assert w == result
-    w[:] = v.ewise_add(v2, Monoid.MAX)
+    w.update(v.ewise_add(v2, Monoid.MAX))
     assert w == result
-    w[:] = v.ewise_add(v2, Semiring.MAX_TIMES)
+    w << v.ewise_add(v2, Semiring.MAX_TIMES)
     assert w == result
 
 def test_extract(v):
     w = Vector.new_from_type(v.dtype, 3)
     result = Vector.new_from_values([0,1], [1,1], size=3)
-    w[:] = v.extract[[1,3,5]]
+    w << v[[1,3,5]]
     assert w == result
-    w[:] = v.extract[1::2]
+    w() << v[1::2]
     assert w == result
-    w2 = v.extract[1::2].new()
+    w2 = v[1::2].new()
     assert w2 == w
 
 def test_assign(v):
     u = Vector.new_from_values([0,2], [9, 8])
     result = Vector.new_from_values([0,1,3,4,6], [9,1,1,8,0])
     w = Vector.new_from_existing(v)
-    w.assign[[0,2,4]] = u
+    w[[0,2,4]] = u
     assert w == result
     w = Vector.new_from_existing(v)
-    w.assign[:5:2] = u
+    w[:5:2] << u
     assert w == result
 
 def test_assign_scalar(v):
     result = Vector.new_from_values([1,3,4,5,6], [9,9,2,9,0])
     w = Vector.new_from_existing(v)
-    w.assign[[1,3,5]] = 9
+    w[[1,3,5]] = 9
     assert w == result
     w = Vector.new_from_existing(v)
-    w.assign[1::2] = 9
+    w[1::2] = 9
     assert w == result
     w = Vector.new_from_values([0,1,2], [1,1,1])
     s = Scalar.new_from_value(9)
-    w.assign[:] = s
+    w[:] = s
     assert w == Vector.new_from_values([0,1,2], [9,9,9])
 
 def test_apply(v):
@@ -221,13 +220,13 @@ def test_reduce(v):
     s = v.reduce(Monoid.PLUS).new()
     assert s == 4
     # Test accum
-    s[BinaryOp.TIMES] = v.reduce(Monoid.PLUS)
+    s(accum=BinaryOp.TIMES) << v.reduce(Monoid.PLUS)
     assert s == 16
 
 def test_simple_assignment(v):
     # w[:] = v
     w = Vector.new_from_type(v.dtype, v.size)
-    w[:] = v
+    w << v
     assert w == v
 
 def test_equal(v):
@@ -241,7 +240,7 @@ def test_equal(v):
 
 def test_binary_op(v):
     v2 = Vector.new_from_existing(v)
-    v2.element[1] = 0
+    v2[1] = 0
     w = v.ewise_mult(v2, BinaryOp.GT).new()
     result = Vector.new_from_values([1,3,4,6], [True, False, False, False])
     assert w.dtype == 'BOOL'


### PR DESCRIPTION
See issue #2 for discussions about these changes.

This is a **MAJOR** syntax refactor. Expect all previous code to break.

Quick overview:
```python
# Old style
C[:] = A.mxm(B)
# New style
C << A.mxm(B)

# Old style with output parameters
C[Q, REPLACE, foobar] = A.mxm(B)
# New style with output parameters (keywords are now possible, making code easier to read)
C(mask=Q, replace=True, accum=foobar) << A.mxm(B)
```