### PR TITLE
Parameterized udfs

### DIFF
--- a/grblas/exceptions.py
+++ b/grblas/exceptions.py
@@ -90,4 +90,7 @@ def is_error(response_code, error_class):
 
 def check_status(response_code):
     if response_code != lib.GrB_SUCCESS:
-        raise _error_code_lookup[response_code](ffi.string(lib.GrB_error()))
+        text = ffi.string(lib.GrB_error())
+        if isinstance(text, bytes):
+            text = text.decode()
+        raise _error_code_lookup[response_code](text)

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -1,6 +1,6 @@
 from functools import partial
 from .base import lib, ffi, GbContainer, GbDelayed
-from .vector import Vector, _generate_isclose
+from .vector import Vector
 from .scalar import Scalar
 from .ops import BinaryOp, find_opclass, find_return_type, reify_op
 from . import dtypes, binary, monoid, semiring
@@ -70,8 +70,7 @@ class Matrix(GbContainer):
         if self.nvals != other.nvals:
             return False
 
-        isclose = _generate_isclose(rel_tol, abs_tol)
-        matches = self.ewise_mult(other, isclose).new(dtype=bool)
+        matches = self.ewise_mult(other, binary.isclose(rel_tol, abs_tol)).new(dtype=bool)
         # ewise_mult performs intersection, so nvals will indicate mismatched empty values
         if matches.nvals != self.nvals:
             return False
@@ -160,6 +159,14 @@ class Matrix(GbContainer):
         dup_orig = dup_op
         if dup_op is None:
             dup_op = binary.plus
+        else:
+            opclass = find_opclass(dup_op)
+            if opclass.startswith('Parameterized'):
+                dup_op = dup_op()  # rely on default parameters
+                opclass = find_opclass(dup_op)
+            if opclass != 'BinaryOp':
+                raise TypeError(f'dup_op must be BinaryOp')
+
         if isinstance(dup_op, BinaryOp):
             dup_op = dup_op[self.dtype]
         rows = ffi.new('GrB_Index[]', rows)
@@ -259,7 +266,10 @@ class Matrix(GbContainer):
         if op is None:
             op = monoid.plus
         opclass = find_opclass(op)
-        if opclass not in ('BinaryOp', 'Monoid', 'Semiring'):
+        if opclass.startswith('Parameterized'):
+            op = op()  # rely on default parameters
+            opclass = find_opclass(op)
+        if opclass not in {'BinaryOp', 'Monoid', 'Semiring'}:
             raise TypeError(f'op must be BinaryOp, Monoid, or Semiring')
         if require_monoid and opclass not in {'Monoid', 'Semiring'}:
             raise TypeError(f'op must be Monoid or Semiring unless require_monoid is False')
@@ -286,7 +296,10 @@ class Matrix(GbContainer):
         if op is None:
             op = binary.times
         opclass = find_opclass(op)
-        if opclass not in ('BinaryOp', 'Monoid', 'Semiring'):
+        if opclass.startswith('Parameterized'):
+            op = op()  # rely on default parameters
+            opclass = find_opclass(op)
+        if opclass not in {'BinaryOp', 'Monoid', 'Semiring'}:
             raise TypeError(f'op must be BinaryOp, Monoid, or Semiring')
         func = getattr(lib, f'GrB_eWiseMult_Matrix_{opclass}')
         op = reify_op(op, self.dtype, other.dtype)
@@ -310,6 +323,9 @@ class Matrix(GbContainer):
         if op is None:
             op = semiring.plus_times
         opclass = find_opclass(op)
+        if opclass.startswith('Parameterized'):
+            op = op()  # rely on default parameters
+            opclass = find_opclass(op)
         if opclass != 'Semiring':
             raise TypeError(f'op must be Semiring')
         op = reify_op(op, self.dtype, other.dtype)
@@ -332,6 +348,9 @@ class Matrix(GbContainer):
         if op is None:
             op = semiring.plus_times
         opclass = find_opclass(op)
+        if opclass.startswith('Parameterized'):
+            op = op()  # rely on default parameters
+            opclass = find_opclass(op)
         if opclass != 'Semiring':
             raise TypeError(f'op must be Semiring')
         op = reify_op(op, self.dtype, other.dtype)
@@ -356,7 +375,10 @@ class Matrix(GbContainer):
         if op is None:
             op = binary.times
         opclass = find_opclass(op)
-        if opclass not in ('BinaryOp', 'Monoid', 'Semiring'):
+        if opclass.startswith('Parameterized'):
+            op = op()  # rely on default parameters
+            opclass = find_opclass(op)
+        if opclass not in {'BinaryOp', 'Monoid', 'Semiring'}:
             raise TypeError(f'op must be BinaryOp, Monoid, or Semiring')
         func = getattr(lib, f'GrB_kronecker_{opclass}')
         op = reify_op(op, self.dtype, other.dtype)
@@ -377,6 +399,9 @@ class Matrix(GbContainer):
             effectively converting a BinaryOp into a UnaryOp
         """
         opclass = find_opclass(op)
+        if opclass.startswith('Parameterized'):
+            op = op()  # rely on default parameters
+            opclass = find_opclass(op)
         if opclass == 'UnaryOp':
             if left is not None or right is not None:
                 raise TypeError('Cannot provide `left` or `right` for a UnaryOp')
@@ -412,7 +437,10 @@ class Matrix(GbContainer):
             else:
                 op = monoid.plus
         opclass = find_opclass(op)
-        if opclass not in ('BinaryOp', 'Monoid'):
+        if opclass.startswith('Parameterized'):
+            op = op()  # rely on default parameters
+            opclass = find_opclass(op)
+        if opclass not in {'BinaryOp', 'Monoid'}:
             raise TypeError(f'op must be BinaryOp or Monoid')
         func = getattr(lib, f'GrB_Matrix_reduce_{opclass}')
         op = reify_op(op, self.dtype)
@@ -443,6 +471,14 @@ class Matrix(GbContainer):
                 op = monoid.lor
             else:
                 op = monoid.plus
+        else:
+            opclass = find_opclass(op)
+            if opclass.startswith('Parameterized'):
+                op = op()  # rely on default parameters
+                opclass = find_opclass(op)
+            if opclass != 'Monoid':
+                raise TypeError(f'op must be Monoid')
+
         func = getattr(lib, f'GrB_Matrix_reduce_{self.dtype.name}')
         op = reify_op(op, self.dtype)
         output_constructor = partial(Scalar.new,

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -160,10 +160,7 @@ class Matrix(GbContainer):
         if dup_op is None:
             dup_op = binary.plus
         else:
-            opclass = find_opclass(dup_op)
-            if opclass.startswith('Parameterized'):
-                dup_op = dup_op()  # rely on default parameters
-                opclass = find_opclass(dup_op)
+            dup_op, opclass = find_opclass(dup_op)
             if opclass != 'BinaryOp':
                 raise TypeError(f'dup_op must be BinaryOp')
 
@@ -265,10 +262,7 @@ class Matrix(GbContainer):
             raise TypeError(f'Expected Matrix, found {type(other)}')
         if op is None:
             op = monoid.plus
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass not in {'BinaryOp', 'Monoid', 'Semiring'}:
             raise TypeError(f'op must be BinaryOp, Monoid, or Semiring')
         if require_monoid and opclass not in {'Monoid', 'Semiring'}:
@@ -295,10 +289,7 @@ class Matrix(GbContainer):
             raise TypeError(f'Expected Matrix, found {type(other)}')
         if op is None:
             op = binary.times
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass not in {'BinaryOp', 'Monoid', 'Semiring'}:
             raise TypeError(f'op must be BinaryOp, Monoid, or Semiring')
         func = getattr(lib, f'GrB_eWiseMult_Matrix_{opclass}')
@@ -322,10 +313,7 @@ class Matrix(GbContainer):
             raise TypeError(f'Expected Vector, found {type(other)}')
         if op is None:
             op = semiring.plus_times
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass != 'Semiring':
             raise TypeError(f'op must be Semiring')
         op = reify_op(op, self.dtype, other.dtype)
@@ -347,10 +335,7 @@ class Matrix(GbContainer):
             raise TypeError(f'Expected Matrix or Vector, found {type(other)}')
         if op is None:
             op = semiring.plus_times
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass != 'Semiring':
             raise TypeError(f'op must be Semiring')
         op = reify_op(op, self.dtype, other.dtype)
@@ -374,10 +359,7 @@ class Matrix(GbContainer):
             raise TypeError(f'Expected Matrix, found {type(other)}')
         if op is None:
             op = binary.times
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass not in {'BinaryOp', 'Monoid', 'Semiring'}:
             raise TypeError(f'op must be BinaryOp, Monoid, or Semiring')
         func = getattr(lib, f'GrB_kronecker_{opclass}')
@@ -398,10 +380,7 @@ class Matrix(GbContainer):
         A BinaryOp can also be applied if a scalar is passed in as `left` or `right`,
             effectively converting a BinaryOp into a UnaryOp
         """
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass == 'UnaryOp':
             if left is not None or right is not None:
                 raise TypeError('Cannot provide `left` or `right` for a UnaryOp')
@@ -436,10 +415,7 @@ class Matrix(GbContainer):
                 op = monoid.lor
             else:
                 op = monoid.plus
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass not in {'BinaryOp', 'Monoid'}:
             raise TypeError(f'op must be BinaryOp or Monoid')
         func = getattr(lib, f'GrB_Matrix_reduce_{opclass}')
@@ -472,10 +448,7 @@ class Matrix(GbContainer):
             else:
                 op = monoid.plus
         else:
-            opclass = find_opclass(op)
-            if opclass.startswith('Parameterized'):
-                op = op()  # rely on default parameters
-                opclass = find_opclass(op)
+            op, opclass = find_opclass(op)
             if opclass != 'Monoid':
                 raise TypeError(f'op must be Monoid')
 

--- a/grblas/monoid/numpy.py
+++ b/grblas/monoid/numpy.py
@@ -29,10 +29,10 @@ _monoid_identities = {
     'bitwise_xor': dict.fromkeys(_bool_int_dtypes, 0),
 
     # Comparison functions
-    # 'equal': {'BOOL': True},  # Not yet supported
-    # 'logical_and': {'BOOL': True},  # Not yet supported
-    # 'logical_or': {'BOOL': True},  # Not yet supported
-    # 'logical_xor': {'BOOL': False},  # Not yet supported
+    'equal': {'BOOL': True},
+    'logical_and': {'BOOL': True},
+    'logical_or': {'BOOL': True},
+    'logical_xor': {'BOOL': False},
     'maximum': {
         'BOOL': False,
         'INT8': np.iinfo(np.int8).min,

--- a/grblas/ops.py
+++ b/grblas/ops.py
@@ -1,8 +1,10 @@
+import inspect
 import re
 import types
 import numpy as np
 import numba
 from collections.abc import Mapping
+from functools import lru_cache
 from types import FunctionType
 from . import lib, ffi, dtypes, unary, binary, monoid, semiring
 from .exceptions import GrblasException, check_status
@@ -19,6 +21,113 @@ class OpPath:
     def __init__(self, parent, name):
         self._parent = parent
         self._name = name
+
+
+class ParameterizedUdf:
+    def __init__(self, name):
+        self.name = name
+        # lru_cache per instance
+        method = self.__call__.__get__(self, self.__class__)
+        self.__call__ = lru_cache(maxsize=1024)(method)
+
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError()
+
+
+class ParameterizedUnaryOp(ParameterizedUdf):
+    def __init__(self, name, func):
+        if not callable(func):
+            return TypeError('func must be callable')
+        self.func = func
+        self.__signature__ = inspect.signature(func)
+        if name is None:
+            name = getattr(func, '__name__', name)
+        super().__init__(name)
+
+    def __call__(self, *args, **kwargs):
+        unary = self.func(*args, **kwargs)
+        return UnaryOp.register_anonymous(unary, self.name)
+
+
+class ParameterizedBinaryOp(ParameterizedUdf):
+    def __init__(self, name, func):
+        if not callable(func):
+            return TypeError('func must be callable')
+        self.func = func
+        self.__signature__ = inspect.signature(func)
+        if name is None:
+            name = getattr(func, '__name__', name)
+        super().__init__(name)
+
+    def __call__(self, *args, **kwargs):
+        binary = self.func(*args, **kwargs)
+        return BinaryOp.register_anonymous(binary, self.name)
+
+
+class ParameterizedMonoid(ParameterizedUdf):
+    def __init__(self, name, binaryop, identity):
+        if not isinstance(binaryop, ParameterizedBinaryOp):
+            raise TypeError('binaropy must be parameterized')
+        self.binaryop = binaryop
+        self.__signature__ = binaryop.__signature__
+        if callable(identity):
+            # assume it must be parameterized as well, so signature must match
+            sig = inspect.signature(identity)
+            if sig != self.__signature__:
+                raise ValueError(
+                    f'Signatures of binarop and identity passed to {type(self).__name__} must be the same.  Got:\n'
+                    f'    binaryop{self.__signature__}\n'
+                    f'    !=\n'
+                    f'    identity{sig}'
+                )
+        self.identity = identity
+        if name is None:
+            name = binaryop.name
+        super().__init__(name)
+
+    def __call__(self, *args, **kwargs):
+        binary = self.binaryop
+        binary = binary(*args, **kwargs)
+        identity = self.identity
+        if callable(identity):
+            identity = identity(*args, **kwargs)
+        return Monoid.register_anonymous(binary, identity, self.name)
+
+
+class ParameterizedSemiring(ParameterizedUdf):
+    def __init__(self, name, monoid, binaryop):
+        if not isinstance(monoid, (ParameterizedMonoid, Monoid)):
+            raise TypeError('monoid must be of type Monoid or ParameterizedMonoid')
+        if isinstance(binaryop, ParameterizedBinaryOp):
+            self.__signature__ = binaryop.__signature__
+            if isinstance(monoid, ParameterizedMonoid) and monoid.__signature__ != self.__signature__:
+                raise ValueError(
+                    f'Signatures of monoid and binarop passed to {type(self).__name__} must be the same.  Got:\n'
+                    f'    monoid{monoid.__signature__}\n'
+                    f'    !=\n'
+                    f'    binaryop{self.__signature__}\n'
+                    '\nPerhaps call monoid or binaryop with parameters before creating the semiring.'
+                )
+        elif isinstance(binaryop, BinaryOp):
+            if isinstance(monoid, Monoid):
+                raise TypeError('At least one of monoid or binaryop must be parameterized')
+            self.__signature__ = monoid.__signature__
+        else:
+            raise TypeError('binaryop must be of type BinaryOp or ParameterizedBinaryOp')
+        self.monoid = monoid
+        self.binaryop = binaryop
+        if name is None:
+            name = f'{monoid.name}_{binaryop.name}'
+        super().__init__(name)
+
+    def __call__(self, *args, **kwargs):
+        monoid = self.monoid
+        if isinstance(monoid, ParameterizedMonoid):
+            monoid = monoid(*args, **kwargs)
+        binary = self.binaryop
+        if isinstance(binary, ParameterizedBinaryOp):
+            binary = binary(*args, **kwargs)
+        return Semiring.register_anonymous(monoid, binary, self.name)
 
 
 class OpBase:
@@ -200,13 +309,18 @@ class UnaryOp(OpBase):
             raise UdfParseError('Unable to parse function using Numba')
 
     @classmethod
-    def register_anonymous(cls, func, name=None):
+    def register_anonymous(cls, func, name=None, *, parameterized=False):
+        if parameterized:
+            return ParameterizedUnaryOp(name, func)
         return cls._build(name, func)
 
     @classmethod
-    def register_new(cls, name, func):
+    def register_new(cls, name, func, *, parameterized=False):
         module, funcname = cls._remove_nesting(name)
-        unary_op = cls._build(name, func)
+        if parameterized:
+            unary_op = ParameterizedUnaryOp(name, func)
+        else:
+            unary_op = cls._build(name, func)
         setattr(module, funcname, unary_op)
 
 
@@ -309,13 +423,18 @@ class BinaryOp(OpBase):
             raise UdfParseError('Unable to parse function using Numba')
 
     @classmethod
-    def register_anonymous(cls, func, name=None):
+    def register_anonymous(cls, func, name=None, *, parameterized=False):
+        if parameterized:
+            return ParameterizedBinaryOp(name, func)
         return cls._build(name, func)
 
     @classmethod
-    def register_new(cls, name, func):
+    def register_new(cls, name, func, *, parameterized=False):
         module, funcname = cls._remove_nesting(name)
-        binary_op = cls._build(name, func)
+        if parameterized:
+            binary_op = ParameterizedBinaryOp(name, func)
+        else:
+            binary_op = cls._build(name, func)
         setattr(module, funcname, binary_op)
 
     @classmethod
@@ -336,6 +455,13 @@ class BinaryOp(OpBase):
         # Add floordiv
         # cdiv truncates towards 0, while floordiv truncates towards -inf
         BinaryOp.register_new('floordiv', lambda x, y: x // y)
+
+        def isclose(rel_tol=1e-7, abs_tol=0.0):
+            def inner(x, y):
+                return x == y or abs(x - y) <= max(rel_tol * max(abs(x), abs(y)), abs_tol)
+            return inner
+
+        BinaryOp.register_new('isclose', isclose, parameterized=True)
 
 
 class Monoid(OpBase):
@@ -370,30 +496,33 @@ class Monoid(OpBase):
             explicit_identities = True
         for type_, identity in identities.items():
             type_ = dtypes.lookup(type_)
-            input_type = dtypes.INT8 if type_ == 'BOOL' else type_
+            ret_type = find_return_type(binaryop[type_])
+            # If there is a domain mismatch, then DomainMismatch will be raised
+            # below if identities were explicitly given.
+            if type_ != ret_type and not explicit_identities:
+                continue
             new_monoid = ffi.new('GrB_Monoid*')
             func = getattr(lib, f'GrB_Monoid_new_{type_.name}')
-            try:
-                zcast = ffi.cast(input_type.c_type, identity)
-                check_status(func(new_monoid, binaryop[type_], zcast))
-            except OverflowError:
-                if explicit_identities:
-                    raise
-                continue
+            zcast = ffi.cast(type_.c_type, identity)
+            check_status(func(new_monoid, binaryop[type_], zcast))
             new_type_obj[type_.name] = new_monoid[0]
-            ret_type = find_return_type(binaryop[type_])
             _return_type[new_monoid[0]] = ret_type
             cls.all_known_instances.add(new_monoid[0])
         return new_type_obj
 
     @classmethod
     def register_anonymous(cls, binaryop, identity, name=None):
+        if isinstance(binaryop, ParameterizedBinaryOp):
+            return ParameterizedMonoid(name, binaryop, identity)
         return cls._build(name, binaryop, identity)
 
     @classmethod
     def register_new(cls, name, binaryop, identity):
         module, funcname = cls._remove_nesting(name)
-        monoid = cls._build(name, binaryop, identity)
+        if isinstance(binaryop, ParameterizedBinaryOp):
+            monoid = ParameterizedMonoid(name, binaryop, identity)
+        else:
+            monoid = cls._build(name, binaryop, identity)
         setattr(module, funcname, monoid)
 
 
@@ -447,17 +576,22 @@ class Semiring(OpBase):
 
     @classmethod
     def register_anonymous(cls, monoid, binaryop, name=None):
+        if isinstance(monoid, ParameterizedMonoid) or isinstance(binaryop, ParameterizedBinaryOp):
+            return ParameterizedSemiring(name, monoid, binaryop)
         return cls._build(name, monoid, binaryop)
 
     @classmethod
     def register_new(cls, name, monoid, binaryop):
         module, funcname = cls._remove_nesting(name)
-        semiring = cls._build(name, monoid, binaryop)
+        if isinstance(monoid, ParameterizedMonoid) or isinstance(binaryop, ParameterizedBinaryOp):
+            semiring = ParameterizedSemiring(name, monoid, binaryop)
+        else:
+            semiring = cls._build(name, monoid, binaryop)
         setattr(module, funcname, semiring)
 
 
 def find_opclass(gb_op):
-    if isinstance(gb_op, OpBase):
+    if isinstance(gb_op, (OpBase, ParameterizedUdf)):
         return gb_op.__class__.__name__
     else:
         for opclass in (UnaryOp, BinaryOp, Monoid, Semiring):

--- a/grblas/ops.py
+++ b/grblas/ops.py
@@ -592,12 +592,18 @@ class Semiring(OpBase):
 
 def find_opclass(gb_op):
     if isinstance(gb_op, (OpBase, ParameterizedUdf)):
-        return gb_op.__class__.__name__
+        opclass = gb_op.__class__.__name__
     else:
         for opclass in (UnaryOp, BinaryOp, Monoid, Semiring):
             if gb_op in opclass.all_known_instances:
-                return opclass.__name__
-    return UNKNOWN_OPCLASS
+                opclass = opclass.__name__
+                break
+        else:
+            opclass = UNKNOWN_OPCLASS
+    if opclass.startswith('Parameterized'):
+        gb_op = gb_op()  # Use default parameters of parameterized UDFs
+        return find_opclass(gb_op)
+    return gb_op, opclass
 
 
 def reify_op(gb_op, dtype, dtype2=None):

--- a/grblas/ops.py
+++ b/grblas/ops.py
@@ -5,7 +5,7 @@ import numba
 from collections.abc import Mapping
 from types import FunctionType
 from . import lib, ffi, dtypes, unary, binary, monoid, semiring
-from .exceptions import GrblasException
+from .exceptions import GrblasException, check_status
 
 
 UNKNOWN_OPCLASS = 'UnknownOpClass'
@@ -157,7 +157,7 @@ class UnaryOp(OpBase):
                 elif type_ == 'BOOL' and ret_type == 'INT64' and return_types.get('INT8') == 'INT8':
                     ret_type = dtypes.INT8
 
-                # Numba has a bug and is unable to handle BOOL correctly right now
+                # Numba is unable to handle BOOL correctly right now, but we have a workaround
                 # See: https://github.com/numba/numba/issues/5395
                 # We're relying on coercion behaving correctly here
                 input_type = dtypes.INT8 if type_ == 'BOOL' else type_
@@ -169,14 +169,20 @@ class UnaryOp(OpBase):
                 wrapper_sig = nt.void(nt.CPointer(return_type.numba_type),
                                       nt.CPointer(input_type.numba_type))
 
-                @numba.cfunc(wrapper_sig, nopython=True)
-                def unary_wrapper(z, x):
-                    result = unary_udf(x[0])
-                    z[0] = result
+                if ret_type == 'BOOL':
+                    @numba.cfunc(wrapper_sig, nopython=True)
+                    def unary_wrapper(z, x):
+                        result = unary_udf(x[0])
+                        z[0] = bool(result)
+                else:
+                    @numba.cfunc(wrapper_sig, nopython=True)
+                    def unary_wrapper(z, x):
+                        result = unary_udf(x[0])
+                        z[0] = result
 
                 new_unary = ffi.new('GrB_UnaryOp*')
-                lib.GrB_UnaryOp_new(new_unary, unary_wrapper.cffi,
-                                    return_type.gb_type, input_type.gb_type)
+                check_status(lib.GrB_UnaryOp_new(new_unary, unary_wrapper.cffi,
+                                                 ret_type.gb_type, type_.gb_type))
                 new_type_obj[type_.name] = new_unary[0]
                 _return_type[new_unary[0]] = ret_type.name
                 cls.all_known_instances.add(new_unary[0])
@@ -252,7 +258,7 @@ class BinaryOp(OpBase):
                 elif type_ == 'BOOL' and ret_type == 'INT64' and return_types.get('INT8') == 'INT8':
                     ret_type = dtypes.INT8
 
-                # Numba has a bug and is unable to handle BOOL correctly right now
+                # Numba is unable to handle BOOL correctly right now, but we have a workaround
                 # See: https://github.com/numba/numba/issues/5395
                 # We're relying on coercion behaving correctly here
                 input_type = dtypes.INT8 if type_ == 'BOOL' else type_
@@ -260,19 +266,28 @@ class BinaryOp(OpBase):
 
                 # JIT the func so it can be used from a cfunc
                 binary_udf = numba.njit(func)
+
                 # Build wrapper because GraphBLAS wants pointers and void return
                 wrapper_sig = nt.void(nt.CPointer(return_type.numba_type),
                                       nt.CPointer(input_type.numba_type),
                                       nt.CPointer(input_type.numba_type))
 
-                @numba.cfunc(wrapper_sig, nopython=True)
-                def binary_wrapper(z, x, y):
-                    result = binary_udf(x[0], y[0])
-                    z[0] = result
+                if ret_type == 'BOOL':
+                    @numba.cfunc(wrapper_sig, nopython=True)
+                    def binary_wrapper(z, x, y):
+                        result = binary_udf(x[0], y[0])
+                        z[0] = bool(result)
+                else:
+                    @numba.cfunc(wrapper_sig, nopython=True)
+                    def binary_wrapper(z, x, y):
+                        result = binary_udf(x[0], y[0])
+                        z[0] = result
 
                 new_binary = ffi.new('GrB_BinaryOp*')
-                lib.GrB_BinaryOp_new(new_binary, binary_wrapper.cffi,
-                                     return_type.gb_type, input_type.gb_type, input_type.gb_type)
+                check_status(
+                    lib.GrB_BinaryOp_new(new_binary, binary_wrapper.cffi,
+                                         ret_type.gb_type, type_.gb_type, type_.gb_type)
+                )
                 new_type_obj[type_.name] = new_binary[0]
                 _return_type[new_binary[0]] = ret_type.name
                 cls.all_known_instances.add(new_binary[0])
@@ -341,16 +356,22 @@ class Monoid(OpBase):
         new_type_obj = cls(name)
         if not isinstance(identity, Mapping):
             identities = dict.fromkeys(binaryop.types, identity)
+            explicit_identities = False
         else:
             identities = identity
+            explicit_identities = True
         for type_, identity in identities.items():
-            if type_ == 'BOOL':  # Not yet supported
-                continue
             type_ = dtypes.lookup(type_)
+            input_type = dtypes.INT8 if type_ == 'BOOL' else type_
             new_monoid = ffi.new('GrB_Monoid*')
             func = getattr(lib, f'GrB_Monoid_new_{type_.name}')
-            zcast = ffi.cast(type_.c_type, identity)
-            func(new_monoid, binaryop[type_], zcast)
+            zcast = ffi.cast(input_type.c_type, identity)
+            try:
+                check_status(func(new_monoid, binaryop[type_], zcast))
+            except OverflowError:
+                if explicit_identities:
+                    raise
+                continue
             new_type_obj[type_.name] = new_monoid[0]
             ret_type = find_return_type(binaryop[type_])
             _return_type[new_monoid[0]] = ret_type
@@ -405,11 +426,11 @@ class Semiring(OpBase):
             binary_out = find_return_type(binary_func)
             # Unfortunately, we can't have user-defined monoids over bools yet
             # because numba can't compile correctly.
-            if binary_out not in monoid.types or binary_out == 'BOOL':
+            if binary_out not in monoid.types:
                 continue
             binary_out = dtypes.lookup(binary_out)
             new_semiring = ffi.new('GrB_Semiring*')
-            lib.GrB_Semiring_new(new_semiring, monoid[binary_out], binary_func)
+            check_status(lib.GrB_Semiring_new(new_semiring, monoid[binary_out], binary_func))
             new_type_obj[binary_in] = new_semiring[0]
             ret_type = find_return_type(monoid[binary_out])
             _return_type[new_semiring[0]] = ret_type

--- a/grblas/semiring/numpy.py
+++ b/grblas/semiring/numpy.py
@@ -57,26 +57,6 @@ _semiring_names -= {
          'logical_and', 'logical_or', 'logical_xor', 'not_equal'}
     )
 }
-# XXX: we can't handle any semirings with bool at the moment
-# <bool>_<bool>
-_semiring_names -= {
-    f'{monoid_name}_{binary_name}'
-    for monoid_name, binary_name in itertools.product(
-        {'add', 'bitwise_and', 'bitwise_or', 'bitwise_xor', 'fmax', 'fmin', 'maximum', 'minimum', 'multiply'},
-        {'equal', 'greater', 'greater_equal', 'less', 'less_equal',
-         'logical_and', 'logical_or', 'logical_xor', 'not_equal'}
-    )
-}
-# <bool>_<non-bool>
-_semiring_names -= {
-    f'{monoid_name}_{binary_name}'
-    for monoid_name, binary_name in itertools.product(
-        {'equal', 'logical_and', 'logical_or', 'logical_xor'},
-        {'add', 'bitwise_and', 'bitwise_or', 'bitwise_xor', 'equal', 'fmax', 'fmin',
-         'greater', 'greater_equal', 'less', 'less_equal', 'logical_and', 'logical_or',
-         'logical_xor', 'maximum', 'minimum', 'multiply', 'not_equal'}
-    )
-}
 
 
 def __dir__():

--- a/grblas/unary/numpy.py
+++ b/grblas/unary/numpy.py
@@ -79,5 +79,5 @@ def __getattr__(name):
     if name == 'reciprocal':
         # numba doesn't match numpy here
         op = ops.UnaryOp.register_anonymous(lambda x: 1 if x else 0)
-        rv._specific_types['BOOL'] = op._specific_types['BOOL']
+        rv['BOOL'] = op['BOOL']
     return rv

--- a/grblas/unary/numpy.py
+++ b/grblas/unary/numpy.py
@@ -6,7 +6,7 @@ https://numba.pydata.org/numba-doc/dev/reference/numpysupported.html#math-operat
 
 """
 import numpy as np
-from .. import ops, unary
+from .. import ops
 
 _unary_names = {
     # Math operations
@@ -76,7 +76,8 @@ def __getattr__(name):
     numpy_func = getattr(np, name)
     ops.UnaryOp.register_new(f'numpy.{name}', lambda x: numpy_func(x))
     rv = globals()[name]
-    if name in {'reciprocal'}:
+    if name == 'reciprocal':
         # numba doesn't match numpy here
-        rv._specific_types['BOOL'] = unary.numpy.abs._specific_types['BOOL']
+        op = ops.UnaryOp.register_anonymous(lambda x: 1 if x else 0)
+        rv._specific_types['BOOL'] = op._specific_types['BOOL']
     return rv

--- a/grblas/unary/numpy.py
+++ b/grblas/unary/numpy.py
@@ -76,7 +76,7 @@ def __getattr__(name):
     numpy_func = getattr(np, name)
     ops.UnaryOp.register_new(f'numpy.{name}', lambda x: numpy_func(x))
     rv = globals()[name]
-    if name in {'invert', 'bitwise_not'}:
-        # numba has difficulty compiling with bool dtypes, so fix our hack
-        rv._specific_types['BOOL'] = unary.numpy.logical_not._specific_types['BOOL']
+    if name in {'reciprocal'}:
+        # numba doesn't match numpy here
+        rv._specific_types['BOOL'] = unary.numpy.abs._specific_types['BOOL']
     return rv

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -135,10 +135,7 @@ class Vector(GbContainer):
         if dup_op is None:
             dup_op = binary.plus
         else:
-            opclass = find_opclass(dup_op)
-            if opclass.startswith('Parameterized'):
-                dup_op = dup_op()  # rely on default parameters
-                opclass = find_opclass(dup_op)
+            dup_op, opclass = find_opclass(dup_op)
             if opclass != 'BinaryOp':
                 raise TypeError(f'dup_op must be BinaryOp')
 
@@ -231,10 +228,7 @@ class Vector(GbContainer):
             raise TypeError(f'Expected Vector, found {type(other)}')
         if op is None:
             op = monoid.plus
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass not in {'BinaryOp', 'Monoid', 'Semiring'}:
             raise TypeError(f'op must be BinaryOp, Monoid, or Semiring')
         if require_monoid and opclass not in {'Monoid', 'Semiring'}:
@@ -259,10 +253,7 @@ class Vector(GbContainer):
             raise TypeError(f'Expected Vector, found {type(other)}')
         if op is None:
             op = binary.times
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass not in {'BinaryOp', 'Monoid', 'Semiring'}:
             raise TypeError(f'op must be BinaryOp, Monoid, or Semiring')
         func = getattr(lib, f'GrB_eWiseMult_Vector_{opclass}')
@@ -285,10 +276,7 @@ class Vector(GbContainer):
             raise TypeError(f'Expected Matrix, found {type(other)}')
         if op is None:
             op = semiring.plus_times
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass != 'Semiring':
             raise TypeError(f'op must be Semiring')
         op = reify_op(op, self.dtype, other.dtype)
@@ -307,10 +295,7 @@ class Vector(GbContainer):
         A BinaryOp can also be applied if a scalar is passed in as `left` or `right`,
             effectively converting a BinaryOp into a UnaryOp
         """
-        opclass = find_opclass(op)
-        if opclass.startswith('Parameterized'):
-            op = op()  # rely on default parameters
-            opclass = find_opclass(op)
+        op, opclass = find_opclass(op)
         if opclass == 'UnaryOp':
             if left is not None or right is not None:
                 raise TypeError('Cannot provide `left` or `right` for a UnaryOp')
@@ -345,10 +330,7 @@ class Vector(GbContainer):
             else:
                 op = monoid.plus
         else:
-            opclass = find_opclass(op)
-            if opclass.startswith('Parameterized'):
-                op = op()  # rely on default parameters
-                opclass = find_opclass(op)
+            op, opclass = find_opclass(op)
             if opclass != 'Monoid':
                 raise TypeError(f'op must be Monoid')
 

--- a/test/test_matrix.py
+++ b/test/test_matrix.py
@@ -452,6 +452,7 @@ def test_isequal(A, v):
     assert not C4.isequal(A)
 
 
+@pytest.mark.slow
 def test_isclose(A, v):
     assert A.isclose(A)
     assert not A.isclose(v)
@@ -481,6 +482,7 @@ def test_isclose(A, v):
     assert C6.isclose(A, rel_tol=1e-3)
 
 
+@pytest.mark.slow
 def test_transpose_equals(A):
     data = [
         [0, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 6],

--- a/test/test_numpyops.py
+++ b/test/test_numpyops.py
@@ -33,7 +33,7 @@ def test_npunary():
         [grblas.Vector.from_values(L, L, dtype='float64'), np.array(L, dtype=np.float64)],
     ]
     blacklist = {}
-    isclose = grblas.vector._generate_isclose(1e-7, 0)
+    isclose = grblas.binary.isclose(1e-7, 0)
     for gb_input, np_input in data:
         for unary_name in sorted(npunary._unary_names):
             op = getattr(npunary, unary_name)
@@ -101,7 +101,7 @@ def test_npbinary():
             'floor_divide',  # numba/numpy difference for 1.0 / 0.0
         },
     }
-    isclose = grblas.vector._generate_isclose(1e-7, 0)
+    isclose = grblas.binary.isclose(1e-7, 0)
     for (gb_left, gb_right), (np_left, np_right) in data:
         for binary_name in sorted(npbinary._binary_names):
             op = getattr(npbinary, binary_name)

--- a/test/test_numpyops.py
+++ b/test/test_numpyops.py
@@ -9,6 +9,7 @@ import grblas.monoid.numpy as npmonoid
 import grblas.semiring.numpy as npsemiring
 
 
+@pytest.mark.slow
 def test_bool_doesnt_get_too_large():
     a = grblas.Vector.from_values([0, 1, 2, 3], [True, False, True, False])
     b = grblas.Vector.from_values([0, 1, 2, 3], [True, True, False, False])

--- a/test/test_op.py
+++ b/test/test_op.py
@@ -101,7 +101,6 @@ def test_monoid_udf():
     BinaryOp.register_new('plus_plus_one', plus_plus_one)
     Monoid.register_new('plus_plus_one', binary.plus_plus_one, -1)
     assert hasattr(monoid, 'plus_plus_one')
-    # No boolean for monoids yet
     assert monoid.plus_plus_one.types == {'INT8', 'INT16', 'INT32', 'INT64',
                                           'UINT8', 'UINT16', 'UINT32', 'UINT64',
                                           'FP32', 'FP64'}
@@ -110,6 +109,10 @@ def test_monoid_udf():
     w = v1.ewise_add(v2, monoid.plus_plus_one).new()
     result = Vector.from_values([0, 1, 2, 3], [4, 2, 3, 4], dtype=dtypes.INT32)
     assert w.isequal(result)
+
+    # -1 doesn't fit in a bool.  Raise if identity explicitly given.
+    with pytest.raises(OverflowError):
+        Monoid.register_anonymous(binary.plus_plus_one, {'BOOL': -1})
 
 
 def test_semiring_udf():

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -319,6 +319,7 @@ def test_isequal(v):
     assert not u4.isequal(v)
 
 
+@pytest.mark.slow
 def test_isclose(v):
     assert v.isclose(v)
     u = Vector.from_values([1], [1])  # wrong size


### PR DESCRIPTION
When registering new unary or binary ops, use `parameterized=True` argument.  Monoids and semirings are implicitly parameterized if an input binaryop or monoid are parameterized.

This PR continued from https://github.com/jim22k/grblas/pull/13, so probably merge that one first.