### PR TITLE
A better way to handle auto-initialization and imports.

### DIFF
--- a/grblas/__init__.py
+++ b/grblas/__init__.py
@@ -2,26 +2,25 @@ import importlib
 from . import backends  # noqa
 
 _init_params = None
-_SPECIAL_ATTRS = ["lib", "ffi", "Matrix", "Vector", "Scalar",
-                  "base", "exceptions", "matrix", "ops", "scalar", "vector",
-                  "unary", "binary", "monoid", "semiring"]
+_SPECIAL_ATTRS = {"lib", "ffi", "Matrix", "Vector", "Scalar",
+                  "exceptions", "matrix", "ops", "scalar", "vector",
+                  "unary", "binary", "monoid", "semiring"}
 
 
 def __getattr__(name):
     """Auto-initialize if special attrs used without explicit init call by user"""
     if name in _SPECIAL_ATTRS:
-        _init("suitesparse", True, automatic=True)
-
+        if _init_params is None:
+            _init("suitesparse", True, automatic=True)
+        if name not in globals():
+            _load(name)
         return globals()[name]
     else:
         raise AttributeError(f"module {__name__!r} has not attribute {name!r}")
 
 
 def __dir__():
-    attrs = list(globals())
-    if "lib" not in attrs:
-        attrs += _SPECIAL_ATTRS
-    return attrs
+    return list(globals().keys() | _SPECIAL_ATTRS)
 
 
 def init(backend="suitesparse", blocking=True):
@@ -29,9 +28,7 @@ def init(backend="suitesparse", blocking=True):
 
 
 def _init(backend, blocking, automatic=False):
-    global _init_params, lib, ffi, Matrix, Vector, Scalar
-    global base, exceptions, matrix, ops, scalar, vector
-    global unary, binary, monoid, semiring
+    global _init_params, lib, ffi
 
     passed_params = dict(backend=backend, blocking=blocking, automatic=automatic)
     if _init_params is None:
@@ -43,41 +40,30 @@ def _init(backend, blocking, automatic=False):
                 raise GrblasException("grblas objects accessed prior to manual initialization")
             else:
                 raise GrblasException("grblas initialized multiple times with different init parameters")
-
         # Already initialized with these parameters; nothing more to do
         return
 
     ffi_backend = importlib.import_module(f'.backends.{backend}', __name__)
-
     lib = ffi_backend.lib
     ffi = ffi_backend.ffi
-
     # This must be called before anything else happens
     if blocking:
         ffi_backend.lib.GrB_init(ffi_backend.lib.GrB_BLOCKING)
     else:
         ffi_backend.lib.GrB_init(ffi_backend.lib.GrB_NONBLOCKING)
 
-    exceptions = importlib.import_module(f".exceptions", __name__)
-    unary = importlib.import_module(f".unary", __name__)
-    binary = importlib.import_module(f".binary", __name__)
-    monoid = importlib.import_module(f".monoid", __name__)
-    semiring = importlib.import_module(f".semiring", __name__)
-    ops = importlib.import_module(f".ops", __name__)
-    base = importlib.import_module(f".base", __name__)
-    matrix = importlib.import_module(f".matrix", __name__)
-    vector = importlib.import_module(f".vector", __name__)
-    scalar = importlib.import_module(f".scalar", __name__)
-    from .matrix import Matrix
-    from .vector import Vector
-    from .scalar import Scalar
 
-    ops.UnaryOp._initialize()
-    ops.BinaryOp._initialize()
-    ops.Monoid._initialize()
-    ops.Semiring._initialize()
-
-    from .unary import numpy  # noqa
-    from .binary import numpy  # noqa
-    from .monoid import numpy  # noqa
-    from .semiring import numpy  # noqa
+def _load(name):
+    if name in {'Matrix', 'Vector', 'Scalar'}:
+        module_name = name.lower()
+        if module_name not in globals():
+            _load(module_name)
+        module = globals()[module_name]
+        val = getattr(module, name)
+        globals()[name] = val
+    elif name in _SPECIAL_ATTRS:
+        # Everything else is a module
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+    else:
+        raise ValueError(name)

--- a/grblas/binary/__init__.py
+++ b/grblas/binary/__init__.py
@@ -1,2 +1,5 @@
 # All items are dynamically added by classes in ops.py
 # This module acts as a container of BinaryOp instances
+from grblas import ops
+from . import numpy  # noqa
+del ops

--- a/grblas/monoid/__init__.py
+++ b/grblas/monoid/__init__.py
@@ -1,2 +1,5 @@
 # All items are dynamically added by classes in ops.py
 # This module acts as a container of Monoid instances
+from grblas import ops
+from . import numpy  # noqa
+del ops

--- a/grblas/ops.py
+++ b/grblas/ops.py
@@ -454,3 +454,10 @@ def find_return_type(gb_op):
     if gb_op not in _return_type:
         raise KeyError('Unknown operator. You must register function prior to use.')
     return _return_type[gb_op]
+
+
+# Now initialize all the things!
+UnaryOp._initialize()
+BinaryOp._initialize()
+Monoid._initialize()
+Semiring._initialize()

--- a/grblas/semiring/__init__.py
+++ b/grblas/semiring/__init__.py
@@ -1,2 +1,5 @@
 # All items are dynamically added by classes in ops.py
 # This module acts as a container of Semiring instances
+from grblas import ops
+from . import numpy  # noqa
+del ops

--- a/grblas/unary/__init__.py
+++ b/grblas/unary/__init__.py
@@ -1,2 +1,5 @@
 # All items are dynamically added by classes in ops.py
 # This module acts as a container of UnaryOp instances
+from grblas import ops
+from . import numpy  # noqa
+del ops


### PR DESCRIPTION
This better leverages the import system.  The previous approach is pretty fragile.

I tested this with the following commands (many of which previously failed):
```bash
python -c 'from grblas import lib'
python -c 'from grblas import ffi'
python -c 'from grblas import base'
python -c 'from grblas.base import IndexerResolver'
python -c 'from grblas import descriptor'
python -c 'from grblas.descriptor import lookup'
python -c 'from grblas import dtypes'
python -c 'from grblas.dtypes import unify'
python -c 'from grblas import exceptions'
python -c 'from grblas.exceptions import check_status'
python -c 'from grblas import io'
python -c 'from grblas.io import to_scipy_sparse_matrix'
python -c 'from grblas import mask'
python -c 'from grblas.mask import ComplementedValueMask'
python -c 'from grblas import matrix'
python -c 'from grblas.matrix import TransposedMatrix'
python -c 'from grblas import ops'
python -c 'from grblas.ops import find_return_type'
python -c 'from grblas import scalar'
python -c 'from grblas.scalar import Scalar'
python -c 'from grblas import vector'
python -c 'from grblas.vector import Vector'
python -c 'from grblas import unary'
python -c 'from grblas.unary import abs'
python -c 'from grblas.unary.numpy import abs'
python -c 'from grblas import binary'
python -c 'from grblas.binary import plus'
python -c 'from grblas.binary.numpy import add'
python -c 'from grblas import monoid'
python -c 'from grblas.monoid import plus'
python -c 'from grblas.monoid.numpy import add'
python -c 'from grblas import semiring'
python -c 'from grblas.semiring import plus_plus'
python -c 'from grblas.semiring.numpy import add_add'
```
Perhaps we could add these (or some of them) to our CI testing.