### PR TITLE
Fix transposed matrix

### DIFF
--- a/grblas/io.py
+++ b/grblas/io.py
@@ -1,4 +1,5 @@
 from . import Matrix, Vector, dtypes
+from .matrix import TransposedMatrix
 from .exceptions import GrblasException
 
 
@@ -10,7 +11,7 @@ def show(m):
         return
 
     print(m)
-    if isinstance(m, Matrix):
+    if isinstance(m, (Matrix, TransposedMatrix)):
         df = pd.DataFrame(columns=range(m.ncols), index=range(m.nrows))
         for i, j, val in zip(*m.to_values()):
             df.iloc[i, j] = val
@@ -41,7 +42,7 @@ def draw(m):
         print('`draw` requires matplotlib to be installed')
         return
 
-    if not isinstance(m, Matrix):
+    if not isinstance(m, (Matrix, TransposedMatrix)):
         print(f'Can only draw a Matrix, not {type(m)}')
         return
 

--- a/grblas/mask.py
+++ b/grblas/mask.py
@@ -10,23 +10,6 @@ class Mask:
         return f'{self.__class__.__name__} of {self.mask}'
 
 
-class ComplementedMask(Mask):
-    complement = True
-    structure = False
-    value = False
-
-    def __invert__(self):
-        return self.mask
-
-    @property
-    def S(self):
-        return ComplementedStructuralMask(self.mask)
-
-    @property
-    def V(self):
-        return ComplementedValueMask(self.mask)
-
-
 class StructuralMask(Mask):
     complement = False
     structure = True

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -552,7 +552,7 @@ class Matrix(GbContainer):
                 delayed = GbDelayed(lib.GrB_Col_assign,
                                     [obj.gb_obj[0], rows, rowsize, col_index])
             else:
-                if not isinstance(obj, Matrix):
+                if not isinstance(obj, (Matrix, TransposedMatrix)):
                     raise TypeError(f'Expected Matrix for assignment value; found {type(obj)}')
                 delayed = GbDelayed(lib.GrB_Matrix_assign,
                                     [obj.gb_obj[0], rows, rowsize, cols, colsize],

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -12,6 +12,8 @@ class Matrix(GbContainer):
     GraphBLAS Sparse Matrix
     High-level wrapper around GrB_Matrix type
     """
+    _is_transposed = False
+
     def __init__(self, gb_obj, dtype):
         super().__init__(gb_obj, dtype)
 
@@ -27,7 +29,7 @@ class Matrix(GbContainer):
         If `check_dtype` is True, also checks that dtypes match
         For equality of floating point Vectors, consider using `isclose`
         """
-        if not isinstance(other, Matrix):
+        if not isinstance(other, (Matrix, TransposedMatrix)):
             return False
         if check_dtype and self.dtype != other.dtype:
             return False
@@ -59,7 +61,7 @@ class Matrix(GbContainer):
         If `check_dtype` is True, also checks that dtypes match
         Closeness check is equivalent to `abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)`
         """
-        if not isinstance(other, Matrix):
+        if not isinstance(other, (Matrix, TransposedMatrix)):
             return False
         if check_dtype and self.dtype != other.dtype:
             return False
@@ -78,9 +80,6 @@ class Matrix(GbContainer):
 
         # Check if all results are True
         return matches.reduce_scalar(monoid.land).value
-
-    def __len__(self):
-        return self.nvals
 
     @property
     def nrows(self):
@@ -107,10 +106,6 @@ class Matrix(GbContainer):
     @property
     def T(self):
         return TransposedMatrix(self)
-
-    @property
-    def is_transposed(self):
-        return False
 
     def clear(self):
         check_status(lib.GrB_Matrix_clear(self.gb_obj[0]))
@@ -260,7 +255,7 @@ class Matrix(GbContainer):
             any operation. In the case of `gt`, the non-empty value is cast to a boolean.
             For these reasons, users are required to be explicit when choosing this surprising behavior.
         """
-        if not isinstance(other, Matrix):
+        if not isinstance(other, (Matrix, TransposedMatrix)):
             raise TypeError(f'Expected Matrix, found {type(other)}')
         if op is None:
             op = monoid.plus
@@ -276,8 +271,8 @@ class Matrix(GbContainer):
                                      nrows=self.nrows, ncols=self.ncols)
         return GbDelayed(func,
                          [op, self.gb_obj[0], other.gb_obj[0]],
-                         at=self.is_transposed,
-                         bt=other.is_transposed,
+                         at=self._is_transposed,
+                         bt=other._is_transposed,
                          output_constructor=output_constructor)
 
     def ewise_mult(self, other, op=None):
@@ -287,7 +282,7 @@ class Matrix(GbContainer):
         Result will contain the intersection of indices from both Matrices
         Default op is binary.times
         """
-        if not isinstance(other, Matrix):
+        if not isinstance(other, (Matrix, TransposedMatrix)):
             raise TypeError(f'Expected Matrix, found {type(other)}')
         if op is None:
             op = binary.times
@@ -301,8 +296,8 @@ class Matrix(GbContainer):
                                      nrows=self.nrows, ncols=self.ncols)
         return GbDelayed(func,
                          [op, self.gb_obj[0], other.gb_obj[0]],
-                         at=self.is_transposed,
-                         bt=other.is_transposed,
+                         at=self._is_transposed,
+                         bt=other._is_transposed,
                          output_constructor=output_constructor)
 
     def mxv(self, other, op=None):
@@ -324,7 +319,7 @@ class Matrix(GbContainer):
                                      size=self.nrows)
         return GbDelayed(lib.GrB_mxv,
                          [op, self.gb_obj[0], other.gb_obj[0]],
-                         at=self.is_transposed,
+                         at=self._is_transposed,
                          output_constructor=output_constructor)
 
     def mxm(self, other, op=None):
@@ -333,7 +328,7 @@ class Matrix(GbContainer):
         Matrix-Matrix multiplication. Result is a Matrix.
         Default op is semiring.plus_times
         """
-        if not isinstance(other, Matrix):
+        if not isinstance(other, (Matrix, TransposedMatrix)):
             raise TypeError(f'Expected Matrix or Vector, found {type(other)}')
         if op is None:
             op = semiring.plus_times
@@ -346,8 +341,8 @@ class Matrix(GbContainer):
                                      nrows=self.nrows, ncols=other.ncols)
         return GbDelayed(lib.GrB_mxm,
                          [op, self.gb_obj[0], other.gb_obj[0]],
-                         at=self.is_transposed,
-                         bt=other.is_transposed,
+                         at=self._is_transposed,
+                         bt=other._is_transposed,
                          output_constructor=output_constructor)
 
     def kronecker(self, other, op=None):
@@ -357,7 +352,7 @@ class Matrix(GbContainer):
         Default op is binary.times
         """
         raise NotImplementedError('Not available in GraphBLAS 1.2')
-        if not isinstance(other, Matrix):
+        if not isinstance(other, (Matrix, TransposedMatrix)):
             raise TypeError(f'Expected Matrix, found {type(other)}')
         if op is None:
             op = binary.times
@@ -371,8 +366,8 @@ class Matrix(GbContainer):
                                      nrows=self.nrows*other.nrows, ncols=self.ncols*other.ncols)
         return GbDelayed(func,
                          [op, self.gb_obj[0], other.gb_obj[0]],
-                         at=self.is_transposed,
-                         bt=other.is_transposed,
+                         at=self._is_transposed,
+                         bt=other._is_transposed,
                          output_constructor=output_constructor)
 
     def apply(self, op, left=None, right=None):
@@ -400,7 +395,7 @@ class Matrix(GbContainer):
         if opclass == 'UnaryOp':
             return GbDelayed(lib.GrB_Matrix_apply,
                              [op, self.gb_obj[0]],
-                             at=self.is_transposed,
+                             at=self._is_transposed,
                              output_constructor=output_constructor)
         else:
             raise NotImplementedError('apply with BinaryOp not available in GraphBLAS 1.2')
@@ -427,7 +422,7 @@ class Matrix(GbContainer):
                                      size=self.nrows)
         return GbDelayed(func,
                          [op, self.gb_obj[0]],
-                         at=self.is_transposed,
+                         at=self._is_transposed,
                          output_constructor=output_constructor)
 
     def reduce_columns(self, op=None):
@@ -465,7 +460,7 @@ class Matrix(GbContainer):
         col, _ = resolved_indexes.indices[1]
         func = getattr(lib, f'GrB_Matrix_extractElement_{self.dtype}')
         result = ffi.new(f'{self.dtype.c_type}*')
-        if self.is_transposed:
+        if self._is_transposed:
             row, col = col, row
 
         err_code = func(result,
@@ -489,7 +484,7 @@ class Matrix(GbContainer):
                                          size=colsize)
             return GbDelayed(lib.GrB_Col_extract,
                              [self.gb_obj[0], cols, colsize, row_index],
-                             at=(not self.is_transposed),
+                             at=(not self._is_transposed),
                              output_constructor=output_constructor)
         elif colsize is None:
             # Column-only selection
@@ -499,7 +494,7 @@ class Matrix(GbContainer):
                                          size=rowsize)
             return GbDelayed(lib.GrB_Col_extract,
                              [self.gb_obj[0], rows, rowsize, col_index],
-                             at=self.is_transposed,
+                             at=self._is_transposed,
                              output_constructor=output_constructor)
         else:
             output_constructor = partial(Matrix.new,
@@ -507,7 +502,7 @@ class Matrix(GbContainer):
                                          nrows=rowsize, ncols=colsize)
             return GbDelayed(lib.GrB_Matrix_extract,
                              [self.gb_obj[0], rows, rowsize, cols, colsize],
-                             at=self.is_transposed,
+                             at=self._is_transposed,
                              output_constructor=output_constructor)
 
     def _assign_element(self, resolved_indexes, value):
@@ -561,62 +556,67 @@ class Matrix(GbContainer):
                     raise TypeError(f'Expected Matrix for assignment value; found {type(obj)}')
                 delayed = GbDelayed(lib.GrB_Matrix_assign,
                                     [obj.gb_obj[0], rows, rowsize, cols, colsize],
-                                    at=obj.is_transposed)
-
+                                    at=obj._is_transposed)
         return delayed
 
 
-class TransposedMatrix(Matrix):
-    def __init__(self, matrix):
-        super().__init__(matrix.gb_obj, matrix.dtype)
-        self._matrix = matrix
+class TransposedMatrix:
+    _is_scalar = False
+    _is_transposed = True
 
-    # Override the default behavior. Don't free gb_obj
-    # because it's shared with the untransposed matrix
-    def __del__(self):
-        pass
+    def __init__(self, matrix):
+        self._matrix = matrix
 
     def __repr__(self):
         return f'<Matrix.T {self.nvals}/({self.nrows}x{self.ncols}):{self.dtype.name}>'
 
-    def new(self, mask=None):
-        output = Matrix.new(self.dtype, self.nrows, self.ncols)
+    def new(self, *, dtype=None, mask=None):
+        if dtype is None:
+            dtype = self.dtype
+        output = Matrix.new(dtype, self.nrows, self.ncols)
         if mask is None:
             output.update(self)
         else:
-            if type(mask) is not Matrix:
-                raise TypeError('Mask must be a Matrix')
             output(mask).update(self)
         return output
-
-    @property
-    def nrows(self):
-        return super().ncols
-
-    @property
-    def ncols(self):
-        return super().nrows
 
     @property
     def T(self):
         return self._matrix
 
     @property
-    def is_transposed(self):
-        return True
+    def gb_obj(self):
+        return self._matrix.gb_obj
 
-    def clear(self):
-        raise Exception('Modification of a transposed Matrix is not allowed')
-
-    def resize(self, nrows, ncols):
-        raise Exception('Modification of a transposed Matrix is not allowed')
-
-    def build(self, rows, columns, values, *, dup_op=None):
-        raise Exception('Modification of a transposed Matrix is not allowed')
-
-    def __setitem__(self, key, val):
-        raise Exception('Assignment to a transposed Matrix is not allowed')
+    @property
+    def dtype(self):
+        return self._matrix.dtype
 
     def to_values(self):
-        rows, cols, vals = super().to_values()
+        rows, cols, vals = self._matrix.to_values()
         return cols, rows, vals
+
+    # Properties
+    nrows = Matrix.ncols
+    ncols = Matrix.nrows
+    shape = Matrix.shape
+    nvals = Matrix.nvals
+
+    # Delayed methods
+    ewise_add = Matrix.ewise_add
+    ewise_mult = Matrix.ewise_mult
+    mxv = Matrix.mxv
+    mxm = Matrix.mxm
+    kronecker = Matrix.kronecker
+    apply = Matrix.apply
+    reduce_rows = Matrix.reduce_rows
+    reduce_columns = Matrix.reduce_columns
+    reduce_scalar = Matrix.reduce_scalar
+
+    # Misc.
+    isequal = Matrix.isequal
+    isclose = Matrix.isclose
+    show = Matrix.show
+    _extract_element = Matrix._extract_element
+    _prep_for_extract = Matrix._prep_for_extract
+    __getitem__ = Matrix.__getitem__

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -7,7 +7,7 @@ class Scalar(GbContainer):
     GraphBLAS Scalar
     Pseudo-object for GraphBLAS functions which accumlate into a scalar type
     """
-    is_scalar = True
+    _is_scalar = True
 
     def __init__(self, gb_obj, dtype, empty=False):
         super().__init__(gb_obj, dtype)

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -281,8 +281,8 @@ class Vector(GbContainer):
         Vector-Matrix multiplication. Result is a Vector.
         Default op is semiring.plus_times
         """
-        from .matrix import Matrix
-        if not isinstance(other, Matrix):
+        from .matrix import Matrix, TransposedMatrix
+        if not isinstance(other, (Matrix, TransposedMatrix)):
             raise TypeError(f'Expected Matrix, found {type(other)}')
         if op is None:
             op = semiring.plus_times
@@ -295,7 +295,7 @@ class Vector(GbContainer):
                                      size=other.ncols)
         return GbDelayed(lib.GrB_vxm,
                          [op, self.gb_obj[0], other.gb_obj[0]],
-                         bt=other.is_transposed,
+                         bt=other._is_transposed,
                          output_constructor=output_constructor)
 
     def apply(self, op, left=None, right=None):

--- a/test/test_matrix.py
+++ b/test/test_matrix.py
@@ -441,6 +441,23 @@ def test_simple_assignment(A):
     assert C.isequal(A)
 
 
+def test_assign_transpose(A):
+    C = Matrix.new(A.dtype, A.ncols, A.nrows)
+    C << A.T
+    assert C.isequal(A.T.new())
+
+    with pytest.raises(TypeError):
+        C.T << A
+    with pytest.raises(TypeError, match='does not support item assignment'):
+        C.T[:, :] << A
+    with pytest.raises(AttributeError):
+        C[:, :].T << A
+
+    C = Matrix.new(A.dtype, A.ncols + 1, A.nrows + 1)
+    C[:A.ncols, :A.nrows] << A.T
+    assert C[:A.ncols, :A.nrows].new().isequal(A.T.new())
+
+
 def test_isequal(A, v):
     assert A.isequal(A)
     assert not A.isequal(v)

--- a/test/test_matrix.py
+++ b/test/test_matrix.py
@@ -505,3 +505,29 @@ def test_transpose_equals(A):
     assert B.isclose(A.T)
     assert A.T.isclose(B)
     assert A.T.isclose(A.T)
+
+
+def test_transpose_exceptional():
+    A = Matrix.from_values([0, 0, 1, 1], [0, 1, 0, 1], [True, True, False, True])
+    B = Matrix.from_values([0, 0, 1, 1], [0, 1, 0, 1], [1, 2, 3, 4])
+
+    with pytest.raises(TypeError, match='not callable'):
+        B.T(mask=A.V) << B.ewise_mult(B, op=binary.plus)
+    with pytest.raises(AttributeError):
+        B(mask=A.T.V) << B.ewise_mult(B, op=binary.plus)
+    with pytest.raises(AttributeError):
+        B.T(mask=A.T.V) << B.ewise_mult(B, op=binary.plus)
+    with pytest.raises(TypeError, match='does not support item assignment'):
+        B.T[1, 0] << 10
+    with pytest.raises(TypeError, match='not callable'):
+        B.T[1, 0]() << 10
+    with pytest.raises(TypeError, match='not callable'):
+        B.T()[1, 0] << 10
+    with pytest.raises(AttributeError):
+        B.T.dup()  # should use new instead
+    # Not exceptional, but while we're here...
+    C = B.T.new(mask=A.V)
+    D = B.T.new()
+    D = D.dup(mask=A.V)
+    assert C.isequal(D)
+    assert C.isequal(Matrix.from_values([0, 0, 1], [0, 1, 1], [1, 3, 4]))


### PR DESCRIPTION
Don't subclass TransposedMatrix from Matrix.  It's not really a GbContainer.  This led to surprising things to be possible.

Instead of blacklisting methods that don't work, choose to be positive and add the ones that do.  I hope this will make it harder to make mistakes in the future.

I took the liberty of moving `is_scalar` and `is_transposed` to private properties.

This PR continues from: https://github.com/jim22k/grblas/pull/15