### PR TITLE
More flexible and explicit handling of scalar update

### DIFF
--- a/grblas/base.py
+++ b/grblas/base.py
@@ -293,6 +293,19 @@ class AmbiguousAssignOrExtract:
         self.resolved_indexes = resolved_indexes
 
     def __call__(self, *args, **kwargs):
+        if type(self.parent) is Updater:
+            parent_kwargs = []
+            if self.parent.kwargs['accum'] is not NULL:
+                parent_kwargs.append(f"accum={self.parent.kwargs['accum']}")
+            if self.parent.kwargs['mask'] is not NULL:
+                # It would sure be nice if we knew the mask type.
+                # Passing around C objects directly is sometimes inconvenient.
+                parent_kwargs.append("mask=<Mask>")
+                parent_kwargs.append(f"replace={self.parent.kwargs['replace']}")
+            if not parent_kwargs:
+                raise ValueError(f'GraphBLAS object already called (with no keywords)')
+            parent_kwargs = ', '.join(parent_kwargs)
+            raise ValueError(f'GraphBLAS object already called with keywords: {parent_kwargs}')
         # Occurs when user calls C[index](params)
         # Reverse the call order so we can parse the call args and kwargs
         updater = self.parent(*args, **kwargs)

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -60,10 +60,14 @@ class GbContainer:
 
     @property
     def S(self):
+        if self._is_scalar:
+            raise AttributeError('Masks not supported for Scalars')
         return StructuralMask(self)
 
     @property
     def V(self):
+        if self._is_scalar:
+            raise AttributeError('Masks not supported for Scalars')
         return ValueMask(self)
 
     def __delitem__(self, keys):
@@ -118,7 +122,11 @@ class GbContainer:
         """
         return self._update(delayed)
 
-    def _update(self, delayed, mask=NULL, accum=NULL, replace=False):
+    def _update(self, delayed, mask=None, accum=None, replace=False):
+        if mask is None:
+            mask = NULL
+        if accum is None:
+            accum = NULL
         # TODO: check expected output type (need to include in GbDelayed object)
         if self._is_scalar and mask is not NULL:
             raise TypeError('Mask not allowed for Scalars')

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -188,7 +188,7 @@ class GbContainer:
 
             call_args = [self.gb_obj, accum] + delayed.tail_args + [desc]
             # Ensure the scalar isn't flagged as empty after the update
-            self.is_empty = False
+            self._is_empty = False
         else:
             call_args = [self.gb_obj[0], mask, accum] + delayed.tail_args + [desc]
 

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -1,7 +1,7 @@
 from . import lib, ffi
 from . import dtypes, ops, descriptor, unary
 from .exceptions import check_status
-from .mask import Mask, StructuralMask, ValueMask
+from .mask import Mask
 
 NULL = ffi.NULL
 
@@ -57,32 +57,6 @@ class GbContainer:
             dtype = dtypes.lookup(dtype)
         self.gb_obj = gb_obj
         self.dtype = dtype
-
-    @property
-    def S(self):
-        if self._is_scalar:
-            raise AttributeError('Masks not supported for Scalars')
-        return StructuralMask(self)
-
-    @property
-    def V(self):
-        if self._is_scalar:
-            raise AttributeError('Masks not supported for Scalars')
-        return ValueMask(self)
-
-    def __delitem__(self, keys):
-        if self._is_scalar:
-            raise TypeError('Indexing not supported for Scalars')
-        raise NotImplementedError('Not available until GraphBLAS v1.3')
-
-    def __getitem__(self, keys):
-        if self._is_scalar:
-            raise TypeError('Indexing not supported for Scalars')
-        resolved_indexes = IndexerResolver(self, keys)
-        return AmbiguousAssignOrExtract(self, resolved_indexes)
-
-    def __setitem__(self, keys, delayed):
-        Updater(self)[keys] = delayed
 
     def __call__(self, *optional_mask_and_accum, mask=None, accum=None, replace=False):
         # Pick out mask and accum from positional arguments

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -441,7 +441,7 @@ class Matrix(GbContainer):
         op = get_typed_op(op, self.dtype)
         if op.opclass != 'Monoid':
             raise TypeError(f'op must be Monoid')
-        func = getattr(lib, f'GrB_Matrix_reduce_{self.dtype.name}')
+        func = getattr(lib, f'GrB_Matrix_reduce_{op.return_type}')
         output_constructor = partial(Scalar.new,
                                      dtype=op.return_type)
         return GbDelayed(func,

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -1,9 +1,10 @@
 from functools import partial
-from .base import lib, ffi, GbContainer, GbDelayed
+from .base import lib, ffi, GbContainer, GbDelayed, IndexerResolver, AmbiguousAssignOrExtract, Updater
 from .vector import Vector
 from .scalar import Scalar
 from .ops import get_typed_op
 from . import dtypes, binary, monoid, semiring
+from .mask import StructuralMask, ValueMask
 from .exceptions import check_status, is_error, NoValue
 
 
@@ -22,6 +23,24 @@ class Matrix(GbContainer):
 
     def __repr__(self):
         return f'<Matrix {self.nvals}/({self.nrows}x{self.ncols}):{self.dtype.name}>'
+
+    @property
+    def S(self):
+        return StructuralMask(self)
+
+    @property
+    def V(self):
+        return ValueMask(self)
+
+    def __delitem__(self, keys):
+        raise NotImplementedError('Not available until GraphBLAS v1.3')
+
+    def __getitem__(self, keys):
+        resolved_indexes = IndexerResolver(self, keys)
+        return AmbiguousAssignOrExtract(self, resolved_indexes)
+
+    def __setitem__(self, keys, delayed):
+        Updater(self)[keys] = delayed
 
     def isequal(self, other, *, check_dtype=False):
         """

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -101,6 +101,12 @@ class Scalar(GbContainer):
             self.gb_obj[0] = val
             self.is_empty = False
 
+    @property
+    def nvals(self):
+        if self.is_empty:
+            return 0
+        return 1
+
     def dup(self, *, dtype=None):
         """Create a new Scalar by duplicating this one
         """

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -13,7 +13,7 @@ class Scalar(GbContainer):
 
     def __init__(self, gb_obj, dtype, empty=False):
         super().__init__(gb_obj, dtype)
-        self.is_empty = empty
+        self._is_empty = empty
 
     def __repr__(self):
         return f'<Scalar {self.value}:{self.dtype}>'
@@ -85,7 +85,11 @@ class Scalar(GbContainer):
             self.value = False
         else:
             self.value = 0
-        self.is_empty = True
+        self._is_empty = True
+
+    @property
+    def is_empty(self):
+        return self._is_empty
 
     @property
     def value(self):
@@ -99,7 +103,7 @@ class Scalar(GbContainer):
             self.clear()
         else:
             self.gb_obj[0] = val
-            self.is_empty = False
+            self._is_empty = False
 
     @property
     def nvals(self):

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -115,7 +115,8 @@ class Scalar(GbContainer):
             new_scalar.value = self.value
         else:
             new_scalar = self.__class__.new(dtype)
-            new_scalar.value = new_scalar.dtype.numba_type(self.value)
+            if not self.is_empty:
+                new_scalar.value = new_scalar.dtype.numba_type(self.value)
         return new_scalar
 
     @classmethod

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -1,8 +1,9 @@
 from functools import partial
-from .base import lib, ffi, GbContainer, GbDelayed
+from .base import lib, ffi, GbContainer, GbDelayed, IndexerResolver, AmbiguousAssignOrExtract, Updater
 from .scalar import Scalar
 from .ops import get_typed_op
 from . import dtypes, binary, monoid, semiring
+from .mask import StructuralMask, ValueMask
 from .exceptions import check_status, is_error, NoValue
 
 
@@ -19,6 +20,24 @@ class Vector(GbContainer):
 
     def __repr__(self):
         return f'<Vector {self.nvals}/{self.size}:{self.dtype.name}>'
+
+    @property
+    def S(self):
+        return StructuralMask(self)
+
+    @property
+    def V(self):
+        return ValueMask(self)
+
+    def __delitem__(self, keys):
+        raise NotImplementedError('Not available until GraphBLAS v1.3')
+
+    def __getitem__(self, keys):
+        resolved_indexes = IndexerResolver(self, keys)
+        return AmbiguousAssignOrExtract(self, resolved_indexes)
+
+    def __setitem__(self, keys, delayed):
+        Updater(self)[keys] = delayed
 
     def isequal(self, other, *, check_dtype=False):
         """

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -338,7 +338,7 @@ class Vector(GbContainer):
         op = get_typed_op(op, self.dtype)
         if op.opclass != 'Monoid':
             raise TypeError(f'op must be Monoid')
-        func = getattr(lib, f'GrB_Vector_reduce_{self.dtype.name}')
+        func = getattr(lib, f'GrB_Vector_reduce_{op.return_type}')
         output_constructor = partial(Scalar.new,
                                      dtype=op.return_type)
         return GbDelayed(func,

--- a/test/test_matrix.py
+++ b/test/test_matrix.py
@@ -1,5 +1,5 @@
 import pytest
-from grblas import Matrix, Vector
+from grblas import Matrix, Vector, Scalar
 from grblas import unary, binary, monoid, semiring
 from grblas import dtypes
 from grblas.exceptions import IndexOutOfBound, DimensionMismatch, OutputNotEmpty
@@ -421,6 +421,20 @@ def test_reduce_column(A):
 def test_reduce_scalar(A):
     s = A.reduce_scalar(monoid.plus).new()
     assert s == 47
+    # test dtype coercion
+    assert A.dtype == dtypes.INT64
+    s = A.reduce_scalar().new(dtype=float)
+    assert s == 47.0
+    assert s.dtype == dtypes.FP64
+    t = Scalar.new(float)
+    t << A.reduce_scalar(monoid.plus)
+    assert t == 47.0
+    t = Scalar.new(float)
+    t() << A.reduce_scalar(monoid.plus)
+    assert t == 47.0
+    t(accum=binary.times) << A.reduce_scalar(monoid.plus)
+    assert t == 47 * 47
+    assert A.reduce_scalar(monoid.plus[dtypes.UINT64]).value == 47
 
 
 def test_transpose(A):

--- a/test/test_resolving.py
+++ b/test/test_resolving.py
@@ -75,3 +75,18 @@ def test_updater_returns_updater():
     assert isinstance(y, Updater)
     final_result = Vector.from_values([0, 1, 3], [-1, -4, -9])
     assert u.isequal(final_result)
+
+
+def test_updater_only_once():
+    u = Vector.from_values([0, 1, 3], [1, 2, 3])
+    with pytest.raises(ValueError, match="already called.*no keywords"):
+        u()[0]()
+    with pytest.raises(ValueError, match="already called.*mask="):
+        u(mask=u.S)[0]()
+    with pytest.raises(ValueError, match="already called.*accum="):
+        u(accum=binary.plus)[0]()
+    with pytest.raises(TypeError, match="not callable"):
+        u()()
+    # While we're at it...
+    with pytest.raises(TypeError, match="is not subscriptable"):
+        u[[0, 1]]()[0]

--- a/test/test_resolving.py
+++ b/test/test_resolving.py
@@ -87,6 +87,12 @@ def test_updater_only_once():
         u(accum=binary.plus)[0]()
     with pytest.raises(TypeError, match="not callable"):
         u()()
+    with pytest.raises(ValueError, match="already called.*no keywords"):
+        u[[0, 1]]()()
     # While we're at it...
     with pytest.raises(TypeError, match="is not subscriptable"):
         u[[0, 1]]()[0]
+    with pytest.raises(TypeError, match="is not subscriptable"):
+        u()[[0, 1]][0]
+    with pytest.raises(TypeError, match="is not subscriptable"):
+        u[[0, 1]][0]

--- a/test/test_scalar.py
+++ b/test/test_scalar.py
@@ -130,3 +130,18 @@ def test_nvals(s):
     assert s.nvals == 1
     s.clear()
     assert s.nvals == 0
+
+
+def test_unsupported_ops(s):
+    with pytest.raises(AttributeError):
+        s.S
+    with pytest.raises(AttributeError):
+        s.V
+    with pytest.raises(AttributeError):
+        s.T
+    with pytest.raises(TypeError, match='is not subscriptable'):
+        s[0]
+    with pytest.raises(TypeError, match='does not support'):
+        s[0] = 0
+    with pytest.raises(TypeError, match="doesn't support"):
+        del s[0]

--- a/test/test_scalar.py
+++ b/test/test_scalar.py
@@ -31,10 +31,19 @@ def test_dup(s):
     assert s3.value == s.value
     # extended functionality
     s4 = Scalar.from_value(-2.5, dtype=dtypes.FP64)
+    s_empty = Scalar.new(dtypes.FP64)
+    s_unempty = Scalar.new(dtypes.FP64)
+    s_unempty.is_empty = False
     for dtype, val in [('INT8', -2), ('INT16', -2), ('INT32', -2), ('UINT8', 2**8 - 2), ('UINT16', 2**16 - 2),
                        ('UINT32', 2**32 - 2), ('UINT64', 2**64 - 2), ('BOOL', True), ('FP32', -2.5)]:
         s5 = s4.dup(dtype=dtype)
         assert s5.dtype == dtype and s5.value == val
+        s6 = s_empty.dup(dtype=dtype)
+        assert s6.is_empty
+        assert s6.value is None
+        s7 = s_unempty.dup(dtype=dtype)
+        assert not s7.is_empty
+        assert s7.value is not None
 
 
 def test_from_value():

--- a/test/test_scalar.py
+++ b/test/test_scalar.py
@@ -12,14 +12,14 @@ def test_new():
     s = Scalar.new(dtypes.INT8)
     assert s.dtype == 'INT8'
     assert s.value is None
-    s.is_empty = False
-    assert s.value == 0  # must hold a value; initialized to 0
+    s.value = 0
+    assert s.is_empty is False
     s2 = Scalar.new(bool)
     assert s2.dtype == 'BOOL'
     assert s2.value is None
     assert bool(s2) is False
-    s2.is_empty = False
-    assert s2.value is False  # must hold a value; initialized to False
+    s2.value = False
+    assert s2.is_empty is False
 
 
 def test_dup(s):
@@ -32,8 +32,7 @@ def test_dup(s):
     # extended functionality
     s4 = Scalar.from_value(-2.5, dtype=dtypes.FP64)
     s_empty = Scalar.new(dtypes.FP64)
-    s_unempty = Scalar.new(dtypes.FP64)
-    s_unempty.is_empty = False
+    s_unempty = Scalar.from_value(0.0)
     for dtype, val in [('INT8', -2), ('INT16', -2), ('INT32', -2), ('UINT8', 2**8 - 2), ('UINT16', 2**16 - 2),
                        ('UINT32', 2**32 - 2), ('UINT64', 2**64 - 2), ('BOOL', True), ('FP32', -2.5)]:
         s5 = s4.dup(dtype=dtype)
@@ -145,3 +144,8 @@ def test_unsupported_ops(s):
         s[0] = 0
     with pytest.raises(TypeError, match="doesn't support"):
         del s[0]
+
+
+def test_is_empty(s):
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        s.is_empty = True

--- a/test/test_scalar.py
+++ b/test/test_scalar.py
@@ -115,3 +115,9 @@ def test_isclose():
     assert not s.isclose(Scalar.from_value(5), check_dtype=True)
     assert not s.isclose(Scalar.from_value(None, dtype=s.dtype))
     assert Scalar.from_value(None, dtype='FP64').isequal(Scalar.from_value(None, dtype='FP32'))
+
+
+def test_nvals(s):
+    assert s.nvals == 1
+    s.clear()
+    assert s.nvals == 0

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -373,8 +373,9 @@ def test_reduce_coerce_dtype(v):
     t = Scalar.new(float)
     t() << v.reduce(monoid.plus)
     assert t == 4.0
-    with pytest.raises(TypeError, match='unable to coerce datatype'):
-        t(accum=binary.times) << v.reduce(monoid.plus)
+    t(accum=binary.times) << v.reduce(monoid.plus)
+    assert t == 16.0
+    assert v.reduce(monoid.plus[dtypes.UINT64]).value == 4
 
 
 def test_simple_assignment(v):


### PR DESCRIPTION
This PR continues from https://github.com/jim22k/grblas/pull/19 to avoid merge conflict.

Scalar reductions are able to specify the result dtype:
    - `v.reduce().new(dtype=float)`
Simple scalar update works:
    - `s << t`
    - `s << 1`
Scalar update with extract element works:
    - `s << v[1]`

More explicit error messages were given for edge cases that don't work.